### PR TITLE
removed namespace

### DIFF
--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -8,7 +8,6 @@ image_resource:
 params:
   SERVICE_ACCOUNT_JSON:
   GCP_PROJECT_NAME:
-  KUBERNETES_NAMESPACE:
   KUBERNETES_CLUSTER:
 
 inputs:
@@ -31,11 +30,10 @@ run:
       # Env vars have to passed one by one as a --env flag each
       # The sleep is to give kubectl time to attach properly, otherwise the first few log lines are lost
       kubectl run acceptance-tests -it --command --rm --quiet \
-      --namespace=${KUBERNETES_NAMESPACE} \
       --generator=run-pod/v1 \
       --image=eu.gcr.io/census-ci/rm/census-rm-acceptance-tests \
       --restart=Never \
       $(while read env; do echo --env=${env}; done < acceptance-tests-repo/kubernetes.env) \
-      --env=REDIS_SERVICE_HOST=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-host}" --namespace=${KUBERNETES_NAMESPACE}) \
-      --env=REDIS_SERVICE_PORT=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-port}" --namespace=${KUBERNETES_NAMESPACE}) \
+      --env=REDIS_SERVICE_HOST=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-host}" }) \
+      --env=REDIS_SERVICE_PORT=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-port}" }) \
       -- /bin/bash -c "sleep 2; behave acceptance_tests/features"


### PR DESCRIPTION
# Motivation and Context
GCP projects to use "default" namespace
<!--- Why is this change required? What problem does it solve? -->

# What has changed
Namespace references removed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
as part of pull request https://github.com/ONSdigital/census-rm-deploy/pull/12

# Links
[Trello](https://trello.com/c/oWQh9Dm4/579-remove-all-references-to-the-response-management-env-kubernetes-namespace)
