### PR TITLE
Set action rules in the future

### DIFF
--- a/acceptance_tests/data_setup/action_setup.py
+++ b/acceptance_tests/data_setup/action_setup.py
@@ -1,27 +1,22 @@
-from acceptance_tests.controllers.action_controller import get_action_plans, create_action_rule
-from acceptance_tests.utilities.date_utilities import get_datetime_now_as_str
+import acceptance_tests.controllers.action_controller as action_controller
+from acceptance_tests.utilities.date_utilities import convert_datetime_to_str
 
 
-def create_action_plan(survey_ref, collection_exercise_id, action_rule_name, action_type_name):
-    trigger_date_time = get_datetime_now_as_str()
-    action_plan_id = _get_id_of_1st_action_plan_for_collection_excercise(collection_exercise_id)
-
+def create_action_rule(survey_ref, action_rule_name, action_type_name, trigger_date, action_plan_id):
     rule = {
         'actionPlanId': action_plan_id,
         'actionTypeName': action_type_name,
         'name': action_rule_name,
         'description': survey_ref,
-        'triggerDateTime': trigger_date_time,
+        'triggerDateTime': convert_datetime_to_str(trigger_date),
         'priority': 3
     }
 
-    create_action_rule(rule)
-
-    return action_plan_id
+    action_controller.create_action_rule(rule)
 
 
-def _get_id_of_1st_action_plan_for_collection_excercise(collection_exercise_id):
-    action_plans = get_action_plans()
+def get_id_of_1st_action_plan_for_collection_excercise(collection_exercise_id):
+    action_plans = action_controller.get_action_plans()
 
     for action_plan in action_plans:
         if _plan_for_collection_exercise(action_plan, collection_exercise_id):

--- a/acceptance_tests/features/sample_file_smoke.feature
+++ b/acceptance_tests/features/sample_file_smoke.feature
@@ -3,6 +3,7 @@ Feature: Smoke tests to check the system is tied together correctly
 
   Scenario: Successful sample file upload
       Given a survey exists with a collection exercise
+      And an action rule of type ICL1E is set 10 seconds in the future
       When sample file "sample_input_census_spec.csv" is loaded
       Then the sample units are created and stored in the case service
-      And correctly formatted notification files are created
+      And correctly formatted print files are created

--- a/acceptance_tests/features/steps/action_steps.py
+++ b/acceptance_tests/features/steps/action_steps.py
@@ -1,0 +1,12 @@
+from datetime import datetime, timedelta
+
+from behave import given
+
+from acceptance_tests.data_setup.action_setup import create_action_rule
+
+
+@given('an action rule of type {action_type} is set {action_rule_delay} seconds in the future')
+def setup_action_rule(context, action_type, action_rule_delay):
+    create_action_rule(context.survey_ref, f'{context.survey_ref} {action_type}', action_type,
+                       datetime.utcnow() + timedelta(seconds=int(action_rule_delay)),
+                       context.action_plan_id)

--- a/acceptance_tests/features/steps/print_file_steps.py
+++ b/acceptance_tests/features/steps/print_file_steps.py
@@ -10,7 +10,7 @@ from acceptance_tests.utilities.sftp_utility import SftpUtility
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-@then("correctly formatted notification files are created")
+@then('correctly formatted print files are created')
 def check_correct_files_on_sftp_server(context):
     expected_csv_lines = create_expected_csv_lines(context)
     _check_notification_files_have_all_the_expected_data(context, expected_csv_lines)

--- a/acceptance_tests/features/steps/sample_steps.py
+++ b/acceptance_tests/features/steps/sample_steps.py
@@ -8,7 +8,8 @@ from acceptance_tests.utilities.sample_loader.load_sample import load_sample_fil
 @when('sample file "{sample_file_name}" is loaded')
 def load_sample_file_step(context, sample_file_name):
     sample_file_name = f'./resources/sample_files/{sample_file_name}'
-    sample_units_raw = load_sample_file(sample_file_name, context.collection_exercise_id, context.action_plan_id,
+    sample_units_raw = load_sample_file(sample_file_name, context.collection_exercise_id,
+                                        context.action_plan_id,
                                         context.collection_instrument_id)
 
     context.sample_units = [

--- a/acceptance_tests/features/steps/survey_steps.py
+++ b/acceptance_tests/features/steps/survey_steps.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from behave import given
 
-from acceptance_tests.data_setup.action_setup import create_action_plan
+from acceptance_tests.data_setup.action_setup import get_id_of_1st_action_plan_for_collection_excercise
 from acceptance_tests.data_setup.collection_exercise_setup import setup_census_collection_exercise
 from acceptance_tests.data_setup.survey_setup import setup_census_survey
 
@@ -12,6 +12,4 @@ def a_survey_exists_with_collex(context):
     context.test_start_datetime = datetime.utcnow()
     setup_census_survey(context)
     setup_census_collection_exercise(context)
-    context.action_plan_id = create_action_plan(context.survey_ref, context.collection_exercise_id,
-                                                'Initial Contact Letter',
-                                                'ICL1E')
+    context.action_plan_id = get_id_of_1st_action_plan_for_collection_excercise(context.collection_exercise_id)

--- a/acceptance_tests/utilities/date_utilities.py
+++ b/acceptance_tests/utilities/date_utilities.py
@@ -1,16 +1,8 @@
 from datetime import datetime, timedelta
 
 
-def get_datetime_now_as_str():
-    return convert_datetime_to_str(datetime.utcnow())
-
-
 def convert_datetime_to_str(date_time):
     return datetime.strftime(date_time, '%Y-%m-%dT%H:%M:%S.000Z')
-
-
-def format_date_as_ddmm(date_to_format):
-    return '{:02d}'.format(date_to_format.day) + "/" + '{:02d}'.format(date_to_format.month)
 
 
 def create_period(period_offset_days=0):


### PR DESCRIPTION
# Motivation and context
In the recent performance changes to the action service (https://github.com/ONSdigital/census-rm-action-service/pull/5) it became a lot more stringent about when it pick up cases for any given action rule, it will only include cases that exist in the action service at the moment the rule triggers, not for a 24 period. This was causing these tests to intermittently fail as they were relying on all the cases reached action in time for an action rule set for the same moment the data was set up. This PR moves the action rule setup into its own step and gives it a configurable delay (since for larger samples it may need longer to ensure the cases have reached action in time).

# What has changed
- Move action rule set up to separate step
- Make the action type and rule delay configurable in step

# How to test?
Run several times, the print file test should now pass reliably where before it was 50/50 if the file actually got generated.

# Links
https://trello.com/c/JbIra0je/644-investigate-print-files-not-being-produced-in-acceptance-tests
