### PR TITLE
Store private key for SFTP SSH as file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ flake:
 test: package_vulnerability flake at_tests
 
 at_tests:
-	SFTP_KEY_FILENAME=dummy_sftp_private_key pipenv run python run.py --log_level WARN
+	SFTP_KEY_FILENAME=dummy_sftp_private_key PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN

--- a/acceptance_tests/utilities/sftp_utility.py
+++ b/acceptance_tests/utilities/sftp_utility.py
@@ -2,7 +2,6 @@ import base64
 from datetime import datetime
 
 import paramiko
-from paramiko import PKey
 
 from config import Config
 
@@ -12,18 +11,16 @@ class SftpUtility:
         self.ssh_client = paramiko.SSHClient()
         self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
-        sftp_key = None
-
         if Config.SFTP_KEY:
-            sftp_key = PKey()
-            sftp_key.load_certificate(base64.b64decode(Config.SFTP_KEY).decode("utf-8"))
-            Config.SFTP_KEY_FILENAME = None
+            private_key_string = base64.b64decode(Config.SFTP_KEY).decode("utf-8")
+            with open('sftp_private_key', 'w') as key_file:
+                key_file.write(private_key_string)
+                Config.SFTP_KEY_FILENAME = key_file.name
 
         self.ssh_client.connect(hostname=Config.SFTP_HOST,
                                 port=int(Config.SFTP_PORT),
                                 username=Config.SFTP_USERNAME,
                                 key_filename=Config.SFTP_KEY_FILENAME,
-                                pkey=sftp_key,
                                 passphrase=Config.SFTP_PASSPHRASE,
                                 look_for_keys=False,
                                 timeout=120)


### PR DESCRIPTION
# Motivation and Context
The acceptance tests keep failing with `binascii.Error: Incorrect padding` type errors. These don't occur when we use a file instead of a string-based key.

# What has changed
Create a temporary file from the string. Supply the file to the SFTP connection settings.

# How to test?
Run ATs in a GKE environment.

# Links
Trello: https://trello.com/c/B6lVt679/611-rmc-179-implement-new-print-file-distribution-method-goanywhere-8