### PR TITLE
Add option to use internal SFTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ To run the acceptance tests (`latest` image in GCR) in a pod in census-rm-ci:
 ```bash
 ./run_gke.sh
 ```
+To run the acceptance tests in a pod in a dev GCP project with a dummy SFTP server:
+```bash
+USE_LOCAL_SFTP=true ENV=test-env ./run_gke.sh
+```
 To run a locally-modified version of the acceptance tests in a pod in a dev GCP project (builds and pushes the docker image to the project's GCR):
 ```bash
 BUILD=true ENV=test-env ./run_gke.sh

--- a/run_gke.sh
+++ b/run_gke.sh
@@ -38,23 +38,43 @@ if [ "$NAMESPACE" ]; then
 fi
 echo "Running RM Acceptance Tests [`kubectl config current-context`]..."
 
-kubectl run acceptance-tests -it --command --rm --quiet --generator=run-pod/v1 \
-    --image=$IMAGE --restart=Never \
-    $(while read env; do echo --env=${env}; done < kubernetes.env) \
-    --env=SFTP_HOST=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.host}" | base64 --decode) \
-    --env=SFTP_USERNAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) \
-    --env=SFTP_KEY=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.private-key}") \
-    --env=SFTP_PASSPHRASE=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.passphrase}" | base64 --decode) \
-    --env=SFTP_DIR=${GCP_PROJECT}/upload/print_service/ \
-    --env=REDIS_SERVICE_HOST=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-host}") \
-    --env=REDIS_SERVICE_PORT=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-port}") \
-    --env=RECEIPT_TOPIC_PROJECT=$(kubectl get configmap pubsub-config -o=jsonpath="{.data.receipt-topic-project-id}") \
-    --env=RECEIPT_TOPIC_ID=$(kubectl get configmap pubsub-config -o=jsonpath="{.data.receipt-topic-name}") \
-    --env=GOOGLE_SERVICE_ACCOUNT_JSON=$(kubectl get secret pubsub-credentials -o=jsonpath="{.data['service-account-key\.json']}") \
-    --env=GOOGLE_APPLICATION_CREDENTIALS="/app/service-account-key.json" \
-    --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
-    --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
-    -- /bin/bash -c "sleep 2; behave acceptance_tests/features --tags=~@local-docker"
+if [ -z "$USE_LOCAL_SFTP" ]; then
+    kubectl run acceptance-tests -it --command --rm --quiet --generator=run-pod/v1 \
+        --image=$IMAGE --restart=Never \
+        $(while read env; do echo --env=${env}; done < kubernetes.env) \
+        --env=SFTP_HOST=sftp \
+        --env=SFTP_USERNAME=testuser \
+        --env=SFTP_PASSWORD=testpassword \
+        --env=SFTP_DIR=upload/print_service/ \
+        --env=REDIS_SERVICE_HOST=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-host}") \
+        --env=REDIS_SERVICE_PORT=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-port}") \
+        --env=RECEIPT_TOPIC_PROJECT=$(kubectl get configmap pubsub-config -o=jsonpath="{.data.receipt-topic-project-id}") \
+        --env=RECEIPT_TOPIC_ID=$(kubectl get configmap pubsub-config -o=jsonpath="{.data.receipt-topic-name}") \
+        --env=GOOGLE_SERVICE_ACCOUNT_JSON=$(kubectl get secret pubsub-credentials -o=jsonpath="{.data['service-account-key\.json']}") \
+        --env=GOOGLE_APPLICATION_CREDENTIALS="/app/service-account-key.json" \
+        --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
+        --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
+        -- /bin/bash -c "sleep 2; behave acceptance_tests/features --tags=~@local-docker"
+else
+    kubectl run acceptance-tests -it --command --rm --quiet --generator=run-pod/v1 \
+        --image=$IMAGE --restart=Never \
+        $(while read env; do echo --env=${env}; done < kubernetes.env) \
+        --env=SFTP_HOST=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.host}" | base64 --decode) \
+        --env=SFTP_USERNAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) \
+        --env=SFTP_KEY=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.private-key}") \
+        --env=SFTP_PASSPHRASE=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.passphrase}" | base64 --decode) \
+        --env=SFTP_DIR=${GCP_PROJECT}/upload/print_service/ \
+        --env=REDIS_SERVICE_HOST=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-host}") \
+        --env=REDIS_SERVICE_PORT=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-port}") \
+        --env=RECEIPT_TOPIC_PROJECT=$(kubectl get configmap pubsub-config -o=jsonpath="{.data.receipt-topic-project-id}") \
+        --env=RECEIPT_TOPIC_ID=$(kubectl get configmap pubsub-config -o=jsonpath="{.data.receipt-topic-name}") \
+        --env=GOOGLE_SERVICE_ACCOUNT_JSON=$(kubectl get secret pubsub-credentials -o=jsonpath="{.data['service-account-key\.json']}") \
+        --env=GOOGLE_APPLICATION_CREDENTIALS="/app/service-account-key.json" \
+        --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
+        --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
+        -- /bin/bash -c "sleep 2; behave acceptance_tests/features --tags=~@local-docker"
+fi
+
 
 # Run acceptance tests for unaddressed batch
 # Pre-delete to avoid unintentionally running with an old image


### PR DESCRIPTION
# Motivation and Context
For developer GKE projects it's convenient to have an internal SFTP server instead of using an external one.

# What has changed
Added option to the `run_gke.sh` script called `USE_LOCAL_SFTP` to use the internal SFTP server instead of the external one.

# How to test?
Terraform a dev project using the `census-rm-terraform` script `USE_LOCAL_SFTP=true ./apply.sh` then run `USE_LOCAL_SFTP=true ENV=test-env ./run_gke.sh`

# Links
Trello: https://trello.com/c/KbLKycCH