### PR TITLE
Defect: project name needed to be set for SFTP

### DIFF
--- a/run_gke.sh
+++ b/run_gke.sh
@@ -38,7 +38,7 @@ if [ "$NAMESPACE" ]; then
 fi
 echo "Running RM Acceptance Tests [`kubectl config current-context`]..."
 
-PROJECT_NAME_CONFIG = $(kubectl get configmap project-config -o=jsonpath="{.data.project-name}")
+PROJECT_NAME_CONFIG=$(kubectl get configmap project-config -o=jsonpath="{.data.project-name}")
 
 kubectl run acceptance-tests -it --command --rm --quiet --generator=run-pod/v1 \
     --image=$IMAGE --restart=Never \

--- a/run_gke.sh
+++ b/run_gke.sh
@@ -38,6 +38,8 @@ if [ "$NAMESPACE" ]; then
 fi
 echo "Running RM Acceptance Tests [`kubectl config current-context`]..."
 
+PROJECT_NAME_CONFIG = $(kubectl get configmap project-config -o=jsonpath="{.data.project-name}")
+
 kubectl run acceptance-tests -it --command --rm --quiet --generator=run-pod/v1 \
     --image=$IMAGE --restart=Never \
     $(while read env; do echo --env=${env}; done < kubernetes.env) \
@@ -45,7 +47,7 @@ kubectl run acceptance-tests -it --command --rm --quiet --generator=run-pod/v1 \
     --env=SFTP_USERNAME=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.username}" | base64 --decode) \
     --env=SFTP_KEY=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.private-key}") \
     --env=SFTP_PASSPHRASE=$(kubectl get secret sftp-ssh-credentials -o=jsonpath="{.data.passphrase}" | base64 --decode) \
-    --env=SFTP_DIR=${GCP_PROJECT}/upload/print_service/ \
+    --env=SFTP_DIR=${PROJECT_NAME_CONFIG}/upload/print_service/ \
     --env=REDIS_SERVICE_HOST=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-host}") \
     --env=REDIS_SERVICE_PORT=$(kubectl get configmap redis-config -o=jsonpath="{.data.redis-port}") \
     --env=RECEIPT_TOPIC_PROJECT=$(kubectl get configmap pubsub-config -o=jsonpath="{.data.receipt-topic-project-id}") \


### PR DESCRIPTION
# Motivation and Context
The project name sometimes isn't specified for the `run_gke.sh` script, but we need if for SFTP.

# What has changed
Retrieve the project name from the config map. Use it.

# How to test?
Run the `run_gke.sh` script without any parameters.

# Links
Trello: https://trello.com/c/dNCPK9t1


# Screenshots (if appropriate):