### PR TITLE
Remove docker push from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,18 +15,11 @@ install:
 script:
   - make package_vulnerability
   - make flake
-
-after_success:
-- if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-  docker build -t "$DESTINATION_IMAGE_NAME" .;
-  docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" "${DOCKER_GCP_REGISTRY}";
-  docker push "$DESTINATION_IMAGE_NAME";
-  fi
+  - make build
 
 env:
   global:
     - PIPENV_IGNORE_VIRTUALENVS=1
-    - DESTINATION_IMAGE_NAME="$DOCKER_GCP_LOCATION/census-rm-acceptance-tests"
 
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ test: package_vulnerability flake at_tests
 
 at_tests:
 	SFTP_KEY_FILENAME=dummy_sftp_private_key PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN
+
+build:
+	docker build -t eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests .


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Concourse will now handle the building and pushing of our Docker services to GCR.

## What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added fail on docker build to script section of Travis file
