### PR TITLE
Add acceptance test for new UAC/QID endpoint in case-api.

### DIFF
--- a/acceptance_tests/features/adhoc_uac_qid.feature
+++ b/acceptance_tests/features/adhoc_uac_qid.feature
@@ -1,0 +1,5 @@
+Feature: Generate new UAC-QID pairs and associated event
+
+  Scenario: Check a UAC QID pair can be generated
+    When a UAC/QID pair is requested with a valid questionnaire type
+    Then caseapi should return a new UAC and QID with correct questionnaire type

--- a/acceptance_tests/features/case_look_up.feature
+++ b/acceptance_tests/features/case_look_up.feature
@@ -27,6 +27,3 @@ Feature: Case look up for the contact centre
     Given a random caseRef is generated
     Then caseapi should return a 404 when queried
 
-  Scenario: Check a UAC QID pair can be generated
-    Given a valid questionnaire id in json
-    Then caseapi should return a 201

--- a/acceptance_tests/features/case_look_up.feature
+++ b/acceptance_tests/features/case_look_up.feature
@@ -26,3 +26,7 @@ Feature: Case look up for the contact centre
   Scenario: Check non-existent caseRef returns a 404 status code
     Given a random caseRef is generated
     Then caseapi should return a 404 when queried
+
+  Scenario: Check a UAC QID pair can be generated
+    Given a valid questionnaire id in json
+    Then caseapi should return a 201

--- a/acceptance_tests/features/steps/adhoc_uac_qid.py
+++ b/acceptance_tests/features/steps/adhoc_uac_qid.py
@@ -1,0 +1,23 @@
+import requests
+import json
+
+from behave import then, when
+from config import Config
+
+caseapi_uacqid_pair_url = f'{Config.CASEAPI_SERVICE}/uacqid/create'
+
+
+@when('a UAC/QID pair is requested with a valid questionnaire type')
+def generate_post_request_body(context):
+    context.uacqid_json = {"questionnaireType":"01"}
+    headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
+    context.response = requests.post(url=caseapi_uacqid_pair_url, data=json.dumps(context.uacqid_json), headers=headers)
+
+
+@then('caseapi should return a new UAC and QID with correct questionnaire type')
+def generate_uacqid_pair(context):
+    assert context.response.status_code == 201
+    response_data = json.loads(context.response.content)
+    assert 'uac' in response_data, 'uac missing in response'
+    assert 'qid' in response_data, 'qid missing in response'
+    assert context.uacqid_json["questionnaireType"] == response_data['qid'][:2]

--- a/acceptance_tests/features/steps/adhoc_uac_qid.py
+++ b/acceptance_tests/features/steps/adhoc_uac_qid.py
@@ -9,7 +9,7 @@ caseapi_uacqid_pair_url = f'{Config.CASEAPI_SERVICE}/uacqid/create'
 
 @when('a UAC/QID pair is requested with a valid questionnaire type')
 def generate_post_request_body(context):
-    context.uacqid_json = {"questionnaireType":"01"}
+    context.uacqid_json = {"questionnaireType": "01"}
     headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
     context.response = requests.post(url=caseapi_uacqid_pair_url, data=json.dumps(context.uacqid_json), headers=headers)
 

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -12,7 +12,6 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
-caseapi_uacqid_pair_url = f'{Config.CASEAPI_SERVICE}/uacqid/create'
 
 
 @then('a case can be retrieved from the caseapi service')
@@ -43,21 +42,6 @@ def generate_random_caseref(context):
     context.random_caseref = randint(15000000, 19999999)
     context.test_endpoint_with_non_existent_value = f'ref/{context.random_caseref}'
     logger.info(f'Dummy caseRef = {context.random_caseref}')
-
-
-@given('a valid questionnaire id in json')
-def generate_post_request_body(context):
-    context.uacqid_json = '{"questionnaire_id":"1"}'
-
-
-@then('caseapi should return a 201')
-def generate_uacqid_pair(context):
-    headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
-    response = requests.post(url=caseapi_uacqid_pair_url, data=context.uacqid_json, headers=headers)
-    assert response.status_code == 201
-    response_data = json.loads(response.content)
-    assert 'uac' in response_data, 'uac missing in response'
-    assert 'qid' in response_data, 'qid missing in response'
 
 
 @then('caseapi should return a 404 when queried')

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -55,6 +55,9 @@ def generate_uacqid_pair(context):
     headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
     response = requests.post(url=caseapi_uacqid_pair_url, data=context.uacqid_json, headers=headers)
     assert response.status_code == 201
+    response_data = json.loads(response.content)
+    assert 'uac' in response_data, 'uac missing in response'
+    assert 'qid' in response_data, 'qid missing in response'
 
 
 @then('caseapi should return a 404 when queried')

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -12,6 +12,7 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
+caseapi_uacqid_pair_url = f'{Config.CASEAPI_SERVICE}/uacqid/create'
 
 
 @then('a case can be retrieved from the caseapi service')
@@ -42,6 +43,18 @@ def generate_random_caseref(context):
     context.random_caseref = randint(15000000, 19999999)
     context.test_endpoint_with_non_existent_value = f'ref/{context.random_caseref}'
     logger.info(f'Dummy caseRef = {context.random_caseref}')
+
+
+@given('a valid questionnaire id in json')
+def generate_post_request_body(context):
+    context.uacqid_json = '{"questionnaire_id":"1"}'
+
+
+@then('caseapi should return a 201')
+def generate_uacqid_pair(context):
+    headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
+    response = requests.post(url=caseapi_uacqid_pair_url, data=context.uacqid_json, headers=headers)
+    assert response.status_code == 201
 
 
 @then('caseapi should return a 404 when queried')


### PR DESCRIPTION
# Motivation and Context
New UAC QID endpoint added to census-rm-case-api

# Links
https://github.com/ONSdigital/census-rm-case-api/pull/18?_pjax=%23js-repo-pjax-container