### PR TITLE
1042 fix action cancel message

### DIFF
--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -52,7 +52,7 @@ def action_cancelled_event_sent_to_fwm(context):
 
     expected_id = context.emitted_case["id"]
     assert context.case_id == expected_id
-    assert context.reason == 'RECEIPTED'
+    assert context.addressType == 'HH'
 
 
 def _field_work_receipt_callback(ch, method, _properties, body, context):
@@ -62,7 +62,7 @@ def _field_work_receipt_callback(ch, method, _properties, body, context):
         ch.basic_nack(delivery_tag=method.delivery_tag)
         assert False, 'Unexpected message on Action.Field case queue, wanted actionCancel'
 
-    context.reason = root[0].find('.//reason').text
+    context.addressType = root[0].find('.//addressType').text
     context.case_id = root[0].find('.//caseId').text
     ch.basic_ack(delivery_tag=method.delivery_tag)
     ch.stop_consuming()

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -50,8 +50,7 @@ def action_cancelled_event_sent_to_fwm(context):
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE_TEST, functools.partial(
         _field_work_receipt_callback, context=context))
 
-    expected_id = context.emitted_case["id"]
-    assert context.case_id == expected_id
+    assert context.fwmt_emitted_case_id == context.emitted_case["id"]
     assert context.addressType == 'HH'
 
 
@@ -63,7 +62,7 @@ def _field_work_receipt_callback(ch, method, _properties, body, context):
         assert False, 'Unexpected message on Action.Field case queue, wanted actionCancel'
 
     context.addressType = root[0].find('.//addressType').text
-    context.case_id = root[0].find('.//caseId').text
+    context.fwmt_emitted_case_id = root[0].find('.//caseId').text
     ch.basic_ack(delivery_tag=method.delivery_tag)
     ch.stop_consuming()
 


### PR DESCRIPTION
# Motivation and Context
ActionCancel was wrong

# What has changed
Looks for addressType in receipt and refusal fwmt emitted events, they also now share a callback

# How to test?
With this branch and the case-api and fwmtadpater installed run the tests locally
https://github.com/ONSdigital/census-rm-case-api/pull/23
https://github.com/ONSdigital/census-rm-fieldwork-adapter/pull/6/files

# Links
https://trello.com/c/B7P71yDJ/1042-cancel-refusal-message-to-the-field-is-incorrect
# Screenshots (if appropriate):