### PR TITLE
check for non-existance of caseId property

### DIFF
--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -84,7 +84,7 @@ def _uac_callback(ch, method, _properties, body, context):
 
     tc.assertEqual(64, len(parsed_body['payload']['uac']['uacHash']))
     tc.assertEqual(context.expected_questionnaire_type, parsed_body['payload']['uac']['questionnaireId'][:2])
-    tc.assertIsNone(parsed_body['payload']['uac']['caseId'])
+    tc.assertNotIn('caseId', parsed_body['payload']['uac'].keys())
     context.expected_message_received = True
     ch.basic_ack(delivery_tag=method.delivery_tag)
     ch.stop_consuming()


### PR DESCRIPTION
# Motivation and Context
null "caseId" values are now suppressed as per [pr](https://github.com/ONSdigital/census-rm-case-processor/pull/48)
<!--- Why is this change required? What problem does it solve? -->

# What has changed
check for non-existance of caseId property instead of 'None'
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->

# How to test?
[as part of](https://github.com/ONSdigital/census-rm-case-processor/pull/48)
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
[Trello](https://trello.com/c/2YY1TOKj/1068-extra-fields-being-shown-on-uac-object-when-qid-linked-event-stored)
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->

# Screenshots (if appropriate):