### PR TITLE
Test address not valid

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -3,5 +3,7 @@ Feature: Address updates
   Scenario: Invalid address
     Given sample file "sample_for_questionnaire_linked.csv" is loaded
     And messages are emitted to RH and Action Scheduler with [01] questionnaire types
-    When an invalid address message is sent
+    When an invalid address message is sent from "CC"
     Then a case_updated msg is emitted where "addressInvalid" is "True"
+    And an ActionCancelled event is sent to field work management
+    And the case event log records invalid address

--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -1,0 +1,7 @@
+Feature: Address updates
+
+  Scenario: Invalid address
+    Given sample file "sample_for_questionnaire_linked.csv" is loaded
+    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
+    When an invalid address message is sent
+    Then a case_updated msg is emitted where "addressInvalid" is "True"

--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -7,7 +7,7 @@ Feature: Case processor handles receipt message from pubsub service
     When the receipt msg for the created case is put on the GCP pubsub
     Then a uac_updated msg is emitted with active set to false
     And a case_updated msg is emitted where "receiptReceived" is "True"
-    And a ActionCancelled event is sent to field work management
+    And an ActionCancelled event is sent to field work management
     And events logged for receipted cases are [RESPONSE_RECEIVED,SAMPLE_LOADED]
 
   Scenario: eQ receipt results in UAC updated event sent to RH, simulate missing case_id
@@ -16,5 +16,5 @@ Feature: Case processor handles receipt message from pubsub service
     When the receipt msg for the created case is put on the GCP pubsub with just qid
     Then a uac_updated msg is emitted with active set to false
     And a case_updated msg is emitted where "receiptReceived" is "True"
-    And a ActionCancelled event is sent to field work management
+    And an ActionCancelled event is sent to field work management
     And events logged for receipted cases are [RESPONSE_RECEIVED,SAMPLE_LOADED]

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -1,13 +1,16 @@
 import json
 
+import requests
 from behave import step
 
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from config import Config
 
+caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
 
-@step("an invalid address message is sent")
-def invalid_address_message(context):
+
+@step('an invalid address message is sent from "{sender}"')
+def invalid_address_message(context, sender):
     context.emitted_case = context.case_created_events[0]['payload']['collectionCase']
 
     message = json.dumps(
@@ -15,7 +18,7 @@ def invalid_address_message(context):
             "event": {
                 "type": "ADDRESS_NOT_VALID",
                 "source": "FIELDWORK_GATEWAY",
-                "channel": "FIELD",
+                "channel": sender,
                 "dateTime": "2019-07-07T22:37:11.988+0000",
                 "transactionId": "d2541acb-230a-4ade-8123-eee2310c9143"
             },
@@ -35,3 +38,13 @@ def invalid_address_message(context):
             message=message,
             content_type='application/json',
             routing_key=Config.RABBITMQ_INVALID_ADDRESS_ROUTING_KEY)
+
+
+@step("the case event log records invalid address")
+def check_case_events(context):
+    response = requests.get(f"{caseapi_url}{context.emitted_case['id']}", params={'caseEvents': True})
+    response_json = response.json()
+    for case_event in response_json['caseEvents']:
+        if case_event['description'] == 'Invalid address':
+            return
+    assert False

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -1,0 +1,37 @@
+import json
+
+from behave import step
+
+from acceptance_tests.utilities.rabbit_context import RabbitContext
+from config import Config
+
+
+@step("an invalid address message is sent")
+def invalid_address_message(context):
+    context.emitted_case = context.case_created_events[0]['payload']['collectionCase']
+
+    message = json.dumps(
+        {
+            "event": {
+                "type": "ADDRESS_NOT_VALID",
+                "source": "FIELDWORK_GATEWAY",
+                "channel": "FIELD",
+                "dateTime": "2019-07-07T22:37:11.988+0000",
+                "transactionId": "d2541acb-230a-4ade-8123-eee2310c9143"
+            },
+            "payload": {
+                "invalidAddress": {
+                    "reason": "DEMOLISHED",
+                    "collectionCase": {
+                        "id": context.emitted_case['id']
+                    }
+                }
+            }
+        }
+    )
+
+    with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
+        rabbit.publish_message(
+            message=message,
+            content_type='application/json',
+            routing_key=Config.RABBITMQ_INVALID_ADDRESS_ROUTING_KEY)

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -44,7 +44,7 @@ def uac_updated_msg_emitted(context):
     assert uac['active'] is False
 
 
-@then("a ActionCancelled event is sent to field work management")
+@then("an ActionCancelled event is sent to field work management")
 def action_cancelled_event_sent_to_fwm(context):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE_TEST, functools.partial(

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -84,7 +84,6 @@ def _uac_callback(ch, method, _properties, body, context):
 
     tc.assertEqual(64, len(parsed_body['payload']['uac']['uacHash']))
     tc.assertEqual(context.expected_questionnaire_type, parsed_body['payload']['uac']['questionnaireId'][:2])
-    tc.assertNotIn('caseId', parsed_body['payload']['uac'].keys())
     context.expected_message_received = True
     ch.basic_ack(delivery_tag=method.delivery_tag)
     ch.stop_consuming()

--- a/config.py
+++ b/config.py
@@ -30,6 +30,8 @@ class Config:
     RABBITMQ_REFUSAL_ROUTING_KEY = os.getenv('RABBITMQ_REFUSAL_ROUTING_KEY', 'event.respondent.refusal')
     RABBITMQ_FULFILMENT_REQUESTED_ROUTING_KEY = os.getenv('RABBITMQ_FULFILMENT_REQUESTED_ROUTING_KEY',
                                                           'event.fulfilment.request')
+    RABBITMQ_INVALID_ADDRESS_ROUTING_KEY = os.getenv('RABBITMQ_INVALID_ADDRESS_ROUTING_KEY',
+                                                     'event.case.address.update')
     RABBITMQ_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', '')
     RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'guest')
     RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'guest')


### PR DESCRIPTION
# Motivation and Context
Fieldwork might discover that an address is not valid and notify RM via a message. We need to handle that message so that we cease doing follow-up actions and we know why we haven't had a response.

# What has changed
Added feature and scenario for receipt of an address invalid message from FWMT.

# How to test?
Run the ATs against the Case Processor from the same branch name.

# Links
Trello: https://trello.com/c/bKxycLe3