### PR TITLE
Removed old field action type FF2QE on test to FIELD

### DIFF
--- a/acceptance_tests/features/field_reminder.feature
+++ b/acceptance_tests/features/field_reminder.feature
@@ -6,7 +6,7 @@ Feature: Reminder messages are emitted to Field Work Management Tool
     Then the action instruction messages are emitted to FWMT where the case has a treatment code of "HH_QF2R1E"
 
   Scenario: Check cases sent to Fieldwork are logged in events
-    Given an action rule of type "FF2QE" is set 2 seconds in the future
+    Given an action rule of type "FIELD" is set 2 seconds in the future
     When sample file "sample_for_field.csv" is loaded
     Then messages are emitted to RH and Action Scheduler with 01 questionnaire types
     And events logged against the case are [FIELD_CASE_SELECTED,SAMPLE_LOADED]


### PR DESCRIPTION
# Motivation and Context
CI Pipeline is broke because a test is using the old action type for field which was FF2QE
# What has changed
- Changed action type on test to `FIELD`
# How to test?
- run acceptance tests
