### PR TITLE
Add QID lookup step to CCS property listed scenario

### DIFF
--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -4,3 +4,4 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     When a CCS Property Listed event is sent
     Then the CCS Property Listed case is created
     And the correct ActionInstruction is sent to FWMT
+    And the case API returns the CCS QID for the new case

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -48,7 +48,7 @@ def generate_random_case_ref(context):
 def get_non_existent_case_id(context):
     response = requests.get(f'{case_api_url}{context.test_endpoint_with_non_existent_value}')
 
-    test_helper.assertEqual(response.status_code, 404, 'Unexpected case returned')
+    test_helper.assertEqual(response.status_code, 404, 'A case was returned when none were expected')
 
 
 @then('case API returns multiple cases for a UPRN')

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -1,8 +1,8 @@
 import functools
 import json
 import uuid
-
 import xml.etree.ElementTree as ET
+
 import requests
 from behave import step, then
 from retrying import retry
@@ -60,12 +60,12 @@ def send_ccs_property_listed_event(context):
 
 @step("the CCS Property Listed case is created")
 @retry(stop_max_attempt_number=10, wait_fixed=1000)
-def check_case_created(context):
+def check_ccs_case_created(context):
     response = requests.get(f"{caseapi_url}{context.case_id}")
-    assert response.status_code == 200, 'CCS Property Listed case not found'
+    test_helper.assertEqual(response.status_code, 200, 'CCS Property Listed case not found')
 
     context.ccs_case = response.json()
-    assert context.ccs_case['caseType'] == 'HH'  # caseType is derived from addressType for CCS
+    test_helper.assertEqual(context.ccs_case['caseType'], 'HH')  # caseType is derived from addressType for CCS
 
 
 @then("the correct ActionInstruction is sent to FWMT")


### PR DESCRIPTION
# Motivation and Context
Case API has a new endpoint to return the CCS QID for a CCS case created by a CCS property listed event.

# What has changed
* Add QID lookup step to CCS property listed scenario
* Replace some bare asserts with test helper method asserts for better logging

# How to test?
Build and run with the linked case-api branch

# Links
https://trello.com/c/T1k3bNPn/1121-implement-field-ccs-eq-launch-5
https://github.com/ONSdigital/census-rm-case-api/pull/33