### PR TITLE
Add scenario for receipting of unlinked QID

### DIFF
--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -171,14 +171,18 @@ def check_message_redelivery_rate(context):
         f'http://{Config.RABBITMQ_HOST}:{Config.RABBITMQ_HTTP_PORT}/api/queues/{v_host}/Case.Responses',
         auth=HTTPBasicAuth(Config.RABBITMQ_USER, Config.RABBITMQ_PASSWORD)).json()
 
-    redeliver_rate = queue_details.get('message_stats', {}).get('redeliver_details', {}).get('rate', 0)
+    queue_details.raise_for_status()
 
-    assert redeliver_rate == 0
+    redeliver_rate = queue_details.get('message_stats', {}).get('redeliver_details', {}).get('rate')
+
+    test_helper.assertEqual(redeliver_rate, 0, "Redeliver rate should be zero")
 
     queue_details = requests.get(
         f'http://{Config.RABBITMQ_HOST}:{Config.RABBITMQ_HTTP_PORT}/api/queues/{v_host}/FieldworkAdapter.uacUpdated',
         auth=HTTPBasicAuth(Config.RABBITMQ_USER, Config.RABBITMQ_PASSWORD)).json()
 
-    redeliver_rate = queue_details.get('message_stats', {}).get('redeliver_details', {}).get('rate', 0)
+    queue_details.raise_for_status()
 
-    assert redeliver_rate == 0
+    redeliver_rate = queue_details.get('message_stats', {}).get('redeliver_details', {}).get('rate')
+
+    test_helper.assertEqual(redeliver_rate, 0, "Redeliver rate should be zero")

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -167,22 +167,21 @@ def check_message_redelivery_rate(context):
     time.sleep(2)  # Wait a couple of seconds for all hell to break loose
 
     v_host = urllib.parse.quote(Config.RABBITMQ_VHOST, safe='')
-    queue_details = requests.get(
+    response = requests.get(
         f'http://{Config.RABBITMQ_HOST}:{Config.RABBITMQ_HTTP_PORT}/api/queues/{v_host}/Case.Responses',
-        auth=HTTPBasicAuth(Config.RABBITMQ_USER, Config.RABBITMQ_PASSWORD)).json()
+        auth=HTTPBasicAuth(Config.RABBITMQ_USER, Config.RABBITMQ_PASSWORD))
 
-    queue_details.raise_for_status()
-
+    response.raise_for_status()
+    queue_details = response.json()
     redeliver_rate = queue_details.get('message_stats', {}).get('redeliver_details', {}).get('rate')
+    test_helper.assertFalse(redeliver_rate, "Redeliver rate should be zero")
 
-    test_helper.assertEqual(redeliver_rate, 0, "Redeliver rate should be zero")
-
-    queue_details = requests.get(
+    response = requests.get(
         f'http://{Config.RABBITMQ_HOST}:{Config.RABBITMQ_HTTP_PORT}/api/queues/{v_host}/FieldworkAdapter.uacUpdated',
-        auth=HTTPBasicAuth(Config.RABBITMQ_USER, Config.RABBITMQ_PASSWORD)).json()
+        auth=HTTPBasicAuth(Config.RABBITMQ_USER, Config.RABBITMQ_PASSWORD))
 
-    queue_details.raise_for_status()
-
+    response.raise_for_status()
+    queue_details = response.json()
     redeliver_rate = queue_details.get('message_stats', {}).get('redeliver_details', {}).get('rate')
 
-    test_helper.assertEqual(redeliver_rate, 0, "Redeliver rate should be zero")
+    test_helper.assertFalse(redeliver_rate, "Redeliver rate should be zero")

--- a/acceptance_tests/features/unaddressed.feature
+++ b/acceptance_tests/features/unaddressed.feature
@@ -18,6 +18,12 @@ Feature: Generating UAC/QID pairs for unaddressed letters & questionnaires
     Then an Individual Questionnaire Linked message is sent
     And a Questionnaire Linked event is logged
 
+  Scenario: Receipt of unlinked unaddressed
+    When an unaddressed message of questionnaire type 01 is sent
+    Then a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
+    And a receipt for the unlinked UAC-QID pair is received
+    Then the world doesn't end
+
   @local-docker
   Scenario: Correct print files generated
     When the unaddressed batch is loaded, the print files are generated

--- a/acceptance_tests/features/unaddressed.feature
+++ b/acceptance_tests/features/unaddressed.feature
@@ -22,7 +22,7 @@ Feature: Generating UAC/QID pairs for unaddressed letters & questionnaires
     When an unaddressed message of questionnaire type 01 is sent
     Then a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     And a receipt for the unlinked UAC-QID pair is received
-    Then the world doesn't end
+    Then message redelivery does not go bananas
 
   @local-docker
   Scenario: Correct print files generated

--- a/config.py
+++ b/config.py
@@ -18,6 +18,7 @@ class Config:
 
     RABBITMQ_HOST = os.getenv('RABBITMQ_SERVICE_HOST', 'localhost')
     RABBITMQ_PORT = os.getenv('RABBITMQ_SERVICE_PORT', '6672')
+    RABBITMQ_HTTP_PORT = os.getenv('RABBITMQ_HTTP_PORT', '16672')
     RABBITMQ_VHOST = os.getenv('RABBITMQ_VHOST', '/')
     RABBITMQ_SAMPLE_INBOUND_QUEUE = os.getenv('RABBITMQ_QUEUE', 'case.sample.inbound')
     RABBITMQ_RH_OUTBOUND_CASE_QUEUE = os.getenv('RABBITMQ_RH_OUTBOUND_CASE_QUEUE', 'case.rh.case')

--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -57,6 +57,7 @@ run:
       --env=GOOGLE_APPLICATION_CREDENTIALS="/app/service-account-key.json" \
       --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
       --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
+      --env=RABBITMQ_HTTP_PORT=15672 \
       --env=NOTIFY_STUB_HOST=notify-stub \
       --env=NOTIFY_STUB_PORT=80 \
       -- /bin/bash -c "sleep 2; behave acceptance_tests/features --tags=~@local-docker"


### PR DESCRIPTION
# Motivation and Context
We had no test coverage for the scenario where we received a receipt for an unlinked QID.

# What has changed
Added scenario.

# How to test?
Run the ATs with `census-rm-docker-dev`, Case Processor and Fieldwork Adapter built from branch `decouple-questionnaire-linked`.

# Links
Trello: https://trello.com/c/YBaj7soL