### PR TITLE
1099 rmc 1663 handle qid linking ccs

### DIFF
--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -3,3 +3,4 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
   Scenario: Log event when a CCS Property Listed event is received
     When a CCS Property Listed event is sent
     Then the CCS Property Listed case is created
+    Then the correct ActionInstruction is sent to FWMT

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -4,11 +4,13 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     When a CCS Property Listed event is sent
     Then the CCS Property Listed case is created
     And the correct ActionInstruction is sent to FWMT
+    And the case API returns the CCS QID for the new case
 
   Scenario: Log event when a CCS Property Listed event is received with a qid
     When an unaddressed message of questionnaire type 71 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     When a CCS Property Listed event is sent with a qid
     And the CCS Property Listed case is created
+    And the CCS Case created is set against the correct qid
     And no ActionInstruction is sent to FWMT
-    And the case API returns the CCS QID for the new case
+

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -3,11 +3,11 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
   Scenario: Log event when a CCS Property Listed event is received with no qid
     When a CCS Property Listed event is sent
     Then the CCS Property Listed case is created
-    Then the correct ActionInstruction is sent to FWMT
+    And the correct ActionInstruction is sent to FWMT
 
   Scenario: Log event when a CCS Property Listed event is received with a qid
     When an unaddressed message of questionnaire type 71 is sent
-    Then a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
+    And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     When a CCS Property Listed event is sent with a qid
-    Then the CCS Property Listed case is created
-    Then no ActionInstruction is sent to FWMT
+    And the CCS Property Listed case is created
+    And no ActionInstruction is sent to FWMT

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -1,0 +1,5 @@
+Feature: Handle CCS (Census Coverage Survey) Property Listed events
+
+  Scenario: Log event when a CCS Property Listed event is received
+    When a CCS Property Listed event is sent
+    Then the CCS Property Listed case is created

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -10,7 +10,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     Given an unaddressed message of questionnaire type 71 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     When a CCS Property Listed event is sent with a qid
-    And the CCS Property Listed case is created
+    Then the CCS Property Listed case is created
     And the CCS Case created is set against the correct qid
     And no ActionInstruction is sent to FWMT
 

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -1,6 +1,13 @@
 Feature: Handle CCS (Census Coverage Survey) Property Listed events
 
-  Scenario: Log event when a CCS Property Listed event is received
-    When a CCS Property Listed event is sent
+  Scenario: Log event when a CCS Property Listed event is received with no qid
+    When a CCS Property Listed event is sent with no qid
     Then the CCS Property Listed case is created
     Then the correct ActionInstruction is sent to FWMT
+
+  Scenario: Log event when a CCS Property Listed event is received wi
+    When an unaddressed message of questionnaire type 71 is sent
+    Then a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
+    When a CCS Property Listed event is sent
+    Then the CCS Property Listed case is created
+    Then no ActionInstruction is sent to FWMT

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -7,7 +7,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     And the case API returns the CCS QID for the new case
 
   Scenario: Log event when a CCS Property Listed event is received with a qid
-    When an unaddressed message of questionnaire type 71 is sent
+    Given an unaddressed message of questionnaire type 71 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     When a CCS Property Listed event is sent with a qid
     And the CCS Property Listed case is created

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -1,0 +1,70 @@
+import json
+import uuid
+
+import requests
+from behave import step
+
+from acceptance_tests.utilities.rabbit_context import RabbitContext
+from config import Config
+
+caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
+
+
+@step("a CCS Property Listed event is sent")
+def send_ccs_property_listed_event(context):
+    context.fieldwork_case = uuid.uuid4()
+
+    message = json.dumps({
+        "event": {
+            "type": "CCS_ADDRESS_LISTED",
+            "source": "FIELDWORK_GATEWAY",
+            "channel": "FIELD",
+            "dateTime": "2011-08-12T20:17:46.384Z",
+            "transactionId": "c45de4dc-3c3b-11e9-b210-d663bd873d93"
+        },
+        "payload": {
+            "CCSProperty": {
+                "collectionCase": {
+                    "id": context.fieldwork_case
+                },
+                "sampleUnit": {
+                    "addressType": "HH",
+                    "estabType": "",
+                    "addressLevel": "U",
+                    "organisationName": "",
+                    "addressLine1": "1 main street",
+                    "addressLine2": "upper upperingham",
+                    "addressLine3": "",
+                    "townName": "upton",
+                    "postcode": "UP103UP",
+                    "latitude": "50.863849",
+                    "longitude": "-1.229710",
+                    "fieldcoordinatorId": "XXXXXXXXXX",
+                    "fieldofficerId": "XXXXXXXXXXXXX"
+                },
+                "uac": {
+                    "questionnaireId": "1110000009"
+                },
+                "refusal": {
+                    "type": "HARD_REFUSAL",
+                    "report": "respondent too busy",
+                    "agentId": "110001"
+                },
+                "invalidAddress": {
+                    "reason": "DEMOLISHED"
+                }
+            }
+        }
+    })
+
+    with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
+        rabbit.publish_message(
+            message=message,
+            content_type='application/json',
+            routing_key=Config.RABBITMQ_CCS_PROPERTY_LISTING_ROUTING_KEY)
+
+
+@step("the CCS Property Listed case is created")
+def check_case_created(context):
+    response = requests.get(f"{caseapi_url}{context.context.fieldwork_case}", params={'caseEvents': True})
+    assert response.status_code == 200, 'CCS Property Listed case has not been created'

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -7,6 +7,7 @@ import requests
 from behave import step
 from retrying import retry
 
+from acceptance_tests.features.steps.unaddressed import get_case_id_by_questionnaire_id
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context, \
     check_no_msgs_sent_to_queue
@@ -128,3 +129,9 @@ def check_no_msg_sent_fwmt(context):
                                 functools.partial(
                                     store_all_msgs_in_context, context=context,
                                     expected_msg_count=0))
+
+
+@step("the CCS Case created is set against the correct qid")
+def check_created_uacqid_link_has_new_ccs_against_it(context):
+    linked_ccs_case_id = get_case_id_by_questionnaire_id(context.expected_questionnaire_id)
+    assert linked_ccs_case_id == context.case_id

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -8,11 +8,63 @@ from behave import step, then
 from retrying import retry
 
 from acceptance_tests.utilities.rabbit_context import RabbitContext
-from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue
+from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context, \
+    check_no_msgs_sent_to_queue
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
+
+
+@step("a CCS Property Listed event is sent with no qid")
+def send_ccs_property_listed_event_with_a_qid(context):
+    context.case_id = str(uuid.uuid4())
+
+    message = json.dumps({
+        "event": {
+            "type": "CCS_ADDRESS_LISTED",
+            "source": "FIELDWORK_GATEWAY",
+            "channel": "FIELD",
+            "dateTime": "2011-08-12T20:17:46.384Z",
+            "transactionId": "c45de4dc-3c3b-11e9-b210-d663bd873d93"
+        },
+        "payload": {
+            "CCSProperty": {
+                "collectionCase": {
+                    "id": context.case_id
+                },
+                "sampleUnit": {
+                    "addressType": "NR",
+                    "estabType": "Non-residential",
+                    "addressLevel": "U",
+                    "organisationName": "Testy McTest",
+                    "addressLine1": "123 Fake street",
+                    "addressLine2": "Upper upperingham",
+                    "addressLine3": "Newport",
+                    "townName": "upton",
+                    "postcode": "UP103UP",
+                    "latitude": "50.863849",
+                    "longitude": "-1.229710",
+                    "fieldcoordinatorId": "XXXXXXXXXX",
+                    "fieldofficerId": "XXXXXXXXXXXXX"
+                },
+                "refusal": {
+                    "type": "HARD_REFUSAL",
+                    "report": "respondent too busy",
+                    "agentId": "110001"
+                },
+                "invalidAddress": {
+                    "reason": "DEMOLISHED"
+                }
+            }
+        }
+    })
+
+    with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
+        rabbit.publish_message(
+            message=message,
+            content_type='application/json',
+            routing_key=Config.RABBITMQ_CCS_PROPERTY_LISTING_ROUTING_KEY)
 
 
 @step("a CCS Property Listed event is sent")
@@ -48,7 +100,7 @@ def send_ccs_property_listed_event(context):
                     "fieldofficerId": "XXXXXXXXXXXXX"
                 },
                 "uac": {
-                    "questionnaireId": "1110000009"
+                    "questionnaireId": context.expected_questionnaire_id
                 },
                 "refusal": {
                     "type": "HARD_REFUSAL",
@@ -107,3 +159,11 @@ def field_callback(ch, method, _properties, body, context):
 
     ch.basic_ack(delivery_tag=method.delivery_tag)
     ch.stop_consuming()
+
+
+@then("no ActionInstruction is sent to FWMT")
+def check_no_msg_sent_fwmt(context):
+    check_no_msgs_sent_to_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE_TEST,
+                                functools.partial(
+                                    store_all_msgs_in_context, context=context,
+                                    expected_msg_count=0))

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -3,6 +3,7 @@ import uuid
 
 import requests
 from behave import step
+from retrying import retry
 
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from config import Config
@@ -65,6 +66,7 @@ def send_ccs_property_listed_event(context):
 
 
 @step("the CCS Property Listed case is created")
+@retry(stop_max_attempt_number=10, wait_fixed=1000)
 def check_case_created(context):
     response = requests.get(f"{caseapi_url}{context.case_id}")
     assert response.status_code == 200, 'CCS Property Listed case not found'

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -12,7 +12,7 @@ caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
 
 @step("a CCS Property Listed event is sent")
 def send_ccs_property_listed_event(context):
-    context.fieldwork_case = uuid.uuid4()
+    context.case_id = str(uuid.uuid4())
 
     message = json.dumps({
         "event": {
@@ -25,16 +25,16 @@ def send_ccs_property_listed_event(context):
         "payload": {
             "CCSProperty": {
                 "collectionCase": {
-                    "id": context.fieldwork_case
+                    "id": context.case_id
                 },
                 "sampleUnit": {
-                    "addressType": "HH",
-                    "estabType": "",
+                    "addressType": "NR",
+                    "estabType": "Non-residential",
                     "addressLevel": "U",
-                    "organisationName": "",
-                    "addressLine1": "1 main street",
-                    "addressLine2": "upper upperingham",
-                    "addressLine3": "",
+                    "organisationName": "Testy McTest",
+                    "addressLine1": "123 Fake street",
+                    "addressLine2": "Upper upperingham",
+                    "addressLine3": "Newport",
                     "townName": "upton",
                     "postcode": "UP103UP",
                     "latitude": "50.863849",
@@ -66,5 +66,9 @@ def send_ccs_property_listed_event(context):
 
 @step("the CCS Property Listed case is created")
 def check_case_created(context):
-    response = requests.get(f"{caseapi_url}{context.context.fieldwork_case}", params={'caseEvents': True})
-    assert response.status_code == 200, 'CCS Property Listed case has not been created'
+    response = requests.get(f"{caseapi_url}{context.case_id}")
+    assert response.status_code == 200, 'CCS Property Listed case not found'
+
+    response_json = response.json()
+    assert response_json['caseType'] == 'NR'    # caseType is derived from addressType for CCS
+

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -4,7 +4,7 @@ import uuid
 
 import xml.etree.ElementTree as ET
 import requests
-from behave import step, then
+from behave import step
 from retrying import retry
 
 from acceptance_tests.utilities.rabbit_context import RabbitContext
@@ -20,37 +20,7 @@ caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
 def send_ccs_property_listed_event(context):
     context.case_id = str(uuid.uuid4())
 
-    message = json.dumps({
-        "event": {
-            "type": "CCS_ADDRESS_LISTED",
-            "source": "FIELDWORK_GATEWAY",
-            "channel": "FIELD",
-            "dateTime": "2011-08-12T20:17:46.384Z",
-            "transactionId": "c45de4dc-3c3b-11e9-b210-d663bd873d93"
-        },
-        "payload": {
-            "CCSProperty": {
-                "collectionCase": {
-                    "id": context.case_id
-                },
-                "sampleUnit": {
-                    "addressType": "HH",
-                    "estabType": "Household",
-                    "addressLevel": "U",
-                    "organisationName": "Testy McTest",
-                    "addressLine1": "123 Fake street",
-                    "addressLine2": "Upper upperingham",
-                    "addressLine3": "Newport",
-                    "townName": "upton",
-                    "postcode": "UP103UP",
-                    "latitude": "50.863849",
-                    "longitude": "-1.229710",
-                    "fieldcoordinatorId": "XXXXXXXXXX",
-                    "fieldofficerId": "XXXXXXXXXXXXX"
-                }
-            }
-        }
-    })
+    message = _get_ccs_property_listed_event(context.case_id)
 
     with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
         rabbit.publish_message(
@@ -62,8 +32,17 @@ def send_ccs_property_listed_event(context):
 @step("a CCS Property Listed event is sent with a qid")
 def send_ccs_property_listed_event_with_qid(context):
     context.case_id = str(uuid.uuid4())
+    message = _get_ccs_property_listed_event(context.case_id, context.expected_questionnaire_id)
 
-    message = json.dumps({
+    with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
+        rabbit.publish_message(
+            message=message,
+            content_type='application/json',
+            routing_key=Config.RABBITMQ_CCS_PROPERTY_LISTING_ROUTING_KEY)
+
+
+def _get_ccs_property_listed_event(case_id, questionnaire_id=None):
+    message = {
         "event": {
             "type": "CCS_ADDRESS_LISTED",
             "source": "FIELDWORK_GATEWAY",
@@ -74,7 +53,7 @@ def send_ccs_property_listed_event_with_qid(context):
         "payload": {
             "CCSProperty": {
                 "collectionCase": {
-                    "id": context.case_id
+                    "id": case_id
                 },
                 "sampleUnit": {
                     "addressType": "HH",
@@ -91,18 +70,16 @@ def send_ccs_property_listed_event_with_qid(context):
                     "fieldcoordinatorId": "XXXXXXXXXX",
                     "fieldofficerId": "XXXXXXXXXXXXX"
                 },
-                "uac": {
-                    "questionnaireId": context.expected_questionnaire_id
-                }
             }
         }
-    })
+    }
 
-    with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
-        rabbit.publish_message(
-            message=message,
-            content_type='application/json',
-            routing_key=Config.RABBITMQ_CCS_PROPERTY_LISTING_ROUTING_KEY)
+    if questionnaire_id:
+        message['payload']['CCSProperty']['uac'] = {
+            "questionnaireId": questionnaire_id
+        }
+
+    return json.dumps(message)
 
 
 @step("the CCS Property Listed case is created")
@@ -115,7 +92,7 @@ def check_case_created(context):
     assert context.ccs_case['caseType'] == 'HH'  # caseType is derived from addressType for CCS
 
 
-@then("the correct ActionInstruction is sent to FWMT")
+@step("the correct ActionInstruction is sent to FWMT")
 def check_correct_ccs_actioninstruction_sent_to_fwmt(context):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE_TEST,
@@ -145,7 +122,7 @@ def field_callback(ch, method, _properties, body, context):
     ch.stop_consuming()
 
 
-@then("no ActionInstruction is sent to FWMT")
+@step("no ActionInstruction is sent to FWMT")
 def check_no_msg_sent_fwmt(context):
     check_no_msgs_sent_to_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE_TEST,
                                 functools.partial(

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -36,7 +36,7 @@ def send_linked_message(context):
 @step("an Individual Questionnaire Linked message is sent")
 def send_individual_linked_message(context):
     check_linked_message_is_received(context)
-    context.linked_case_id = _get_case_id_by_questionnaire_id(context.expected_questionnaire_id)
+    context.linked_case_id = get_case_id_by_questionnaire_id(context.expected_questionnaire_id)
 
 
 def check_linked_message_is_received(context):
@@ -92,7 +92,7 @@ def check_question_linked_event_is_logged(context):
 
 
 @retry(stop_max_attempt_number=10, wait_fixed=1000)
-def _get_case_id_by_questionnaire_id(questionnaire_id):
+def get_case_id_by_questionnaire_id(questionnaire_id):
     response = requests.get(f'{caseapi_url}/qid/{questionnaire_id}')
     assert response.status_code == 200, "Unexpected status code"
     response_json = response.json()

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -22,7 +22,7 @@ logger = wrap_logger(logging.getLogger(__name__))
 caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
 
 
-@when('an unaddressed message of questionnaire type {questionnaire_type} is sent')
+@step('an unaddressed message of questionnaire type {questionnaire_type} is sent')
 def send_unaddressed_message(context, questionnaire_type):
     context.expected_questionnaire_type = questionnaire_type
     with RabbitContext(queue_name=Config.RABBITMQ_UNADDRESSED_REQUEST_QUEUE) as rabbit:

--- a/config.py
+++ b/config.py
@@ -35,6 +35,8 @@ class Config:
                                                           'event.fulfilment.request')
     RABBITMQ_INVALID_ADDRESS_ROUTING_KEY = os.getenv('RABBITMQ_INVALID_ADDRESS_ROUTING_KEY',
                                                      'event.case.address.update')
+    RABBITMQ_CCS_PROPERTY_LISTING_ROUTING_KEY = os.getenv('RABBITMQ_CCS_PROPERTY_LISTING_ROUTING_KEY',
+                                                          'event.ccs.propertylisting')
     RABBITMQ_EXCHANGE = os.getenv('RABBITMQ_EXCHANGE', '')
     RABBITMQ_USER = os.getenv('RABBITMQ_USER', 'guest')
     RABBITMQ_PASSWORD = os.getenv('RABBITMQ_PASSWORD', 'guest')


### PR DESCRIPTION
# Motivation and Context
https://trello.com/c/KNsTMSMf/1099-rmc-1663-handle-qid-linking-in-ccspropertylisted-event-5

# What has changed
New test to check if passing a qid with the a CCSCaseListed results in no msg being sent to fwmt

# How to test?
Install https://github.com/ONSdigital/census-rm-case-processor/tree/1099-css-with-qid then run the tests

# Links
https://trello.com/c/KNsTMSMf/1099-rmc-1663-handle-qid-linking-in-ccspropertylisted-event-5

# Screenshots (if appropriate):