### PR TITLE
Verify active flag on CCS QID endpoint response

### DIFF
--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -81,6 +81,7 @@ def get_ccs_qid_for_case_id(context):
     test_helper.assertEqual(response.status_code, 200, 'CCS QID API call failed')
     response_json = json.loads(response.text)
     test_helper.assertEqual(response_json['qid'][0:3], '712', 'CCS QID has incorrect questionnaire type or tranche ID')
+    test_helper.assertTrue(response_json['active'])
 
 
 def get_logged_events_for_case_by_id(case_id):


### PR DESCRIPTION
# Motivation and Context
The active flag is now required in the response from the CCS QID endpoint

# What has changed
* Test active flag on CCS QID response

# How to test?
Run with linked branch of case API

# Links
https://trello.com/c/BveqdONB/1253-return-qid-active-status-on-field-eq-launch-api-3
https://github.com/ONSdigital/census-rm-case-api/pull/35