### PR TITLE
Added test for CCS invalidAddress

### DIFF
--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -20,3 +20,10 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     And no ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case
 
+  Scenario: CCS Listed with Address invalid
+    When a CCS Property Listed event is sent with an address invalid event and addressType "NR"
+    Then the CCS Property Listed case is created with case_type "NR"
+    And the CCS case listed event is logged
+    And no ActionInstruction is sent to FWMT
+    And the case API returns the CCS QID for the new case
+

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -110,7 +110,7 @@ def check_case_created(context, case_type):
     test_helper.assertEqual(response.status_code, 200, 'CCS Property Listed case not found')
 
     context.ccs_case = response.json()
-    test_helper.assertEqual(context.ccs_case['caseType'], case_type) # caseType is derived from addressType for CCS
+    test_helper.assertEqual(context.ccs_case['caseType'], case_type)
 
 
 @step("the correct ActionInstruction is sent to FWMT")

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -45,6 +45,16 @@ def send_ccs_property_listed_event_with_refusal(context):
     _send_ccs_case_list_msg_to_rabbit(message)
 
 
+@step('a CCS Property Listed event is sent with an address invalid event and addressType "{address_type}"')
+def send_ccs_property_listed_event_with_invalid_address(context, address_type):
+    message = _create_ccs_property_listed_event(context, address_type)
+    message['payload']['CCSProperty']['invalidAddress'] = {
+        "reason": "NON_RESIDENTIAL"
+    }
+
+    _send_ccs_case_list_msg_to_rabbit(message)
+
+
 def _create_ccs_property_listed_event(context, address_type="HH"):
     context.case_id = str(uuid.uuid4())
 
@@ -100,7 +110,7 @@ def check_case_created(context, case_type):
     test_helper.assertEqual(response.status_code, 200, 'CCS Property Listed case not found')
 
     context.ccs_case = response.json()
-    test_helper.assertEqual(context.ccs_case['caseType'], case_type)  # caseType is derived from addressType for CCS
+    test_helper.assertEqual(context.ccs_case['caseType'], case_type) # caseType is derived from addressType for CCS
 
 
 @step("the correct ActionInstruction is sent to FWMT")


### PR DESCRIPTION
# Motivation and Context
Test for CCSPropertyList event with invalid address object

# What has changed
tests for this

# How to test?
run tests locally with case processor from this branch 

# Links
https://github.com/ONSdigital/census-rm-case-processor/tree/ccs-invalid-address

# Screenshots (if appropriate):