### PR TITLE
New fields on case api

### DIFF
--- a/acceptance_tests/features/case_look_up.feature
+++ b/acceptance_tests/features/case_look_up.feature
@@ -27,3 +27,13 @@ Feature: Case look up for the contact centre
     Given a random caseRef is generated
     Then case API should return a 404 when queried
 
+  Scenario: Check case-api returns correct fields for a CENSUS case
+    Given sample file "sample_1_english_unit.csv" is loaded
+    Then messages are emitted to RH and Action Scheduler with [01] questionnaire types
+    Then a case can be retrieved from the case API service
+    And it contains the correct fields for a CENSUS case
+
+  Scenario: Check case-api returns correct fields for a CCS case
+    When a CCS Property Listed event is sent
+    Then the CCS Property Listed case is created with case_type "HH"
+    And it contains the correct fields for a CCS case

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -20,9 +20,9 @@ def get_case_by_id(context):
 
     response = requests.get(f'{case_api_url}{case_id}')
 
-    context.response = response.json()
-
     test_helper.assertEqual(response.status_code, 200, 'Case not found')
+
+    context.case_details = response.json()
 
 
 @given('a random caseId is generated')
@@ -88,31 +88,31 @@ def get_ccs_qid_for_case_id(context):
 
 @step('it contains the correct fields for a CENSUS case')
 def check_census_case_fields(context):
-    assert context.response['caseRef']
-    assert context.response['arid']
-    assert context.response['estabArid']
-    assert context.response['estabType']
-    assert context.response['uprn']
-    assert context.response['collectionExerciseId']
-    test_helper.assertEqual(context.response['surveyType'], "CENSUS")
-    assert context.response['createdDateTime']
-    assert context.response['addressLine1']
-    assert context.response['addressLine2']
-    assert context.response['addressLine3']
-    assert context.response['townName']
-    assert context.response['postcode']
-    assert context.response['addressLevel']
-    assert context.response['abpCode']
-    assert context.response['region']
-    assert context.response['latitude']
-    assert context.response['longitude']
-    assert context.response['oa']
-    assert context.response['lsoa']
-    assert context.response['msoa']
-    assert context.response['lad']
-    assert context.response['state']
-    assert context.response['id']
-    assert context.response['caseType']
+    assert context.case_details['caseRef']
+    assert context.case_details['arid']
+    assert context.case_details['estabArid']
+    assert context.case_details['estabType']
+    assert context.case_details['uprn']
+    assert context.case_details['collectionExerciseId']
+    test_helper.assertEqual(context.case_details['surveyType'], "CENSUS")
+    assert context.case_details['createdDateTime']
+    assert context.case_details['addressLine1']
+    assert context.case_details['addressLine2']
+    assert context.case_details['addressLine3']
+    assert context.case_details['townName']
+    assert context.case_details['postcode']
+    assert context.case_details['addressLevel']
+    assert context.case_details['abpCode']
+    assert context.case_details['region']
+    assert context.case_details['latitude']
+    assert context.case_details['longitude']
+    assert context.case_details['oa']
+    assert context.case_details['lsoa']
+    assert context.case_details['msoa']
+    assert context.case_details['lad']
+    assert context.case_details['state']
+    assert context.case_details['id']
+    assert context.case_details['caseType']
 
 
 @step('it contains the correct fields for a CCS case')

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -20,6 +20,8 @@ def get_case_by_id(context):
 
     response = requests.get(f'{case_api_url}{case_id}')
 
+    context.response = response.json()
+
     test_helper.assertEqual(response.status_code, 200, 'Case not found')
 
 
@@ -82,6 +84,64 @@ def get_ccs_qid_for_case_id(context):
     response_json = json.loads(response.text)
     test_helper.assertEqual(response_json['qid'][0:3], '712', 'CCS QID has incorrect questionnaire type or tranche ID')
     test_helper.assertTrue(response_json['active'])
+
+
+@step('it contains the correct fields for a CENSUS case')
+def check_census_case_fields(context):
+    assert context.response['caseRef']
+    assert context.response['arid']
+    assert context.response['estabArid']
+    assert context.response['estabType']
+    assert context.response['uprn']
+    assert context.response['collectionExerciseId']
+    test_helper.assertEqual(context.response['surveyType'], "CENSUS")
+    assert context.response['createdDateTime']
+    assert context.response['addressLine1']
+    assert context.response['addressLine2']
+    assert context.response['addressLine3']
+    assert context.response['townName']
+    assert context.response['postcode']
+    assert context.response['addressLevel']
+    assert context.response['abpCode']
+    assert context.response['region']
+    assert context.response['latitude']
+    assert context.response['longitude']
+    assert context.response['oa']
+    assert context.response['lsoa']
+    assert context.response['msoa']
+    assert context.response['lad']
+    assert context.response['state']
+    assert context.response['id']
+    assert context.response['caseType']
+
+
+@step('it contains the correct fields for a CCS case')
+def check_ccs_case_fields(context):
+    assert context.ccs_case['caseRef']
+    test_helper.assertFalse(context.ccs_case['arid'])
+    test_helper.assertFalse(context.ccs_case['estabArid'])
+    assert context.ccs_case['estabType']
+    test_helper.assertFalse(context.ccs_case['uprn'])
+    assert context.ccs_case['collectionExerciseId']
+    test_helper.assertEqual(context.ccs_case['surveyType'], "CCS")
+    assert context.ccs_case['createdDateTime']
+    assert context.ccs_case['addressLine1']
+    assert context.ccs_case['addressLine2']
+    assert context.ccs_case['addressLine3']
+    assert context.ccs_case['townName']
+    assert context.ccs_case['postcode']
+    assert context.ccs_case['addressLevel']
+    test_helper.assertFalse(context.ccs_case['abpCode'])
+    test_helper.assertFalse(context.ccs_case['region'])
+    assert context.ccs_case['latitude']
+    assert context.ccs_case['longitude']
+    test_helper.assertFalse(context.ccs_case['oa'])
+    test_helper.assertFalse(context.ccs_case['lsoa'])
+    test_helper.assertFalse(context.ccs_case['msoa'])
+    test_helper.assertFalse(context.ccs_case['lad'])
+    assert context.ccs_case['state']
+    assert context.ccs_case['id']
+    assert context.ccs_case['caseType']
 
 
 def get_logged_events_for_case_by_id(case_id):


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Two extra fields need to be returned from case-api, collectionExerciseId and surveyType(inferred from ccs_case boolean).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Tests added to check what fields are returned depending on case survey type (CCS or CENSUS).

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run alongside the case-api branch of the [same name](https://github.com/ONSdigital/census-rm-case-api/pull/36).

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/BGuOGSeR/1263-new-fields-on-case-api-5
https://github.com/ONSdigital/census-rm-case-api/pull/36
# Screenshots (if appropriate):