### PR TITLE
Add port for rabbitmq api for test to pass in personal cloud projects

### DIFF
--- a/run_gke.sh
+++ b/run_gke.sh
@@ -63,6 +63,7 @@ kubectl run acceptance-tests -it --command --rm --quiet --generator=run-pod/v1 \
     --env=GOOGLE_APPLICATION_CREDENTIALS="/app/service-account-key.json" \
     --env=RABBITMQ_USER=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-username}" | base64 --decode) \
     --env=RABBITMQ_PASSWORD=$(kubectl get secret rabbitmq -o=jsonpath="{.data.rabbitmq-password}" | base64 --decode) \
+    --env=RABBITMQ_HTTP_PORT=15672 \
     --env=NOTIFY_STUB_HOST=notify-stub \
     --env=NOTIFY_STUB_PORT=80 \
     -- /bin/bash -c "sleep 2; behave acceptance_tests/features --tags=~@local-docker"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The receipt of unlinked unaddressed test was failing in personal cloud projects as the acceptance tests didn't have the rabbit api port env variable set.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Env variable added to ./run_gke script.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Checkout branch
On terminal:
`BUILD=true ENV=yourenv ./run_gke` or just `./run_gke`

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/wZiFpYr9/1322-add-rabbitmq-api-environment-variable-to-script-for-running-acceptance-tests-in-personal-projects
# Screenshots (if appropriate):