### PR TITLE
Fix CCS case API call to use key in spec

### DIFF
--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -82,7 +82,8 @@ def get_ccs_qid_for_case_id(context):
     response = requests.get(f'{case_api_url}ccs/{context.ccs_case["id"]}/qid')
     test_helper.assertEqual(response.status_code, 200, 'CCS QID API call failed')
     response_json = json.loads(response.text)
-    test_helper.assertEqual(response_json['qid'][0:3], '712', 'CCS QID has incorrect questionnaire type or tranche ID')
+    test_helper.assertEqual(response_json['questionnaireId'][0:3],
+                            '712', 'CCS QID has incorrect questionnaire type or tranche ID')
     test_helper.assertTrue(response_json['active'])
 
 


### PR DESCRIPTION
# Motivation and Context
The `qid` JSON key does not match the API spec, it should be `questionnaireId`

# What has changed
* Fix CCS case API call to use key in spec

# How to test?
Build and run the linked case API branch, run these tests

# Links
https://trello.com/c/PaAl8jVl/1353-defect-case-api-for-ccs-to-get-qid-doesnt-match-spec
https://github.com/ONSdigital/census-rm-case-api/pull/40