### PR TITLE
Add test to check bad messages are placed on redelivery queue

### DIFF
--- a/acceptance_tests/features/bad_message.feature
+++ b/acceptance_tests/features/bad_message.feature
@@ -1,0 +1,7 @@
+Feature: identify bad messages
+
+  Scenario: Bad messages on RM queues are put on redelivery queue
+    Given queues are free of messages
+    When a bad message is placed on each of the queues
+    Then the hash of the bad message is seen multiple times
+    And queues are free of messages

--- a/acceptance_tests/features/bad_message.feature
+++ b/acceptance_tests/features/bad_message.feature
@@ -1,7 +1,6 @@
 Feature: identify bad messages
 
+  @clear_for_bad_messages
   Scenario: Bad messages on RM queues are put on redelivery queue
-    Given queues are free of messages
-    When a bad message is placed on each of the queues
-    Then the hash of the bad message is seen multiple times
-    And queues are free of messages
+    Given a bad message is placed on each of the queues
+    Then each bad message is seen multiple times by the exception manager

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -1,6 +1,9 @@
 import base64
 import json
+import time
 import uuid
+import requests
+
 from datetime import datetime
 
 from acceptance_tests.utilities.rabbit_helper import add_test_queue, purge_queues
@@ -39,6 +42,24 @@ def before_scenario(context, _):
                  Config.RABBITMQ_OUTBOUND_FIELD_QUEUE_TEST,
                  Config.RABBITMQ_INBOUND_FULFILMENT_REQUEST_QUEUE,
                  Config.RABBITMQ_INBOUND_NOTIFY_FULFILMENT_REQUEST_QUEUE)
+
+
+def before_tag(context, tag):
+    if tag == "clear_for_bad_messages":
+        __clear_queues_for_bad_messages()
+
+
+def after_tag(context, tag):
+    if tag == "clear_for_bad_messages":
+        __clear_queues_for_bad_messages()
+
+
+def __clear_queues_for_bad_messages():
+    for i in range(0, 4):
+        purge_queues(*Config.RABBITMQ_QUEUES, 'delayedRedeliveryQueue', 'RM.Field')
+        time.sleep(1)
+    time.sleep(5)
+    requests.get(f'{Config.EXCEPTION_MANAGER_URL}/reset')
 
 
 def _setup_google_auth():

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -46,15 +46,15 @@ def before_scenario(context, _):
 
 def before_tag(context, tag):
     if tag == "clear_for_bad_messages":
-        __clear_queues_for_bad_messages()
+        _clear_queues_for_bad_messages_and_reset_exception_manager()
 
 
 def after_tag(context, tag):
     if tag == "clear_for_bad_messages":
-        __clear_queues_for_bad_messages()
+        _clear_queues_for_bad_messages_and_reset_exception_manager()
 
 
-def __clear_queues_for_bad_messages():
+def _clear_queues_for_bad_messages_and_reset_exception_manager():
     for i in range(0, 4):
         purge_queues(*Config.RABBITMQ_QUEUES, 'delayedRedeliveryQueue', 'RM.Field')
         time.sleep(1)

--- a/acceptance_tests/features/steps/bad_message.py
+++ b/acceptance_tests/features/steps/bad_message.py
@@ -4,23 +4,13 @@ import time
 import uuid
 import requests
 
-from behave import when, then, step
+from behave import then, given
 
 from acceptance_tests.utilities.rabbit_context import RabbitContext
-from acceptance_tests.utilities.rabbit_helper import purge_queues
 from config import Config
 
 
-@step('queues are free of messages')
-def clear_queues(context):
-    for i in range(0, 4):
-        purge_queues(*Config.RABBITMQ_QUEUES, 'delayedRedeliveryQueue', 'RM.Field')
-        time.sleep(1)
-    time.sleep(5)
-    requests.get(f'{Config.EXCEPTION_MANAGER_URL}/reset')
-
-
-@when('a bad message is placed on each of the queues')
+@given('a bad message is placed on each of the queues')
 def publish_bad_message(context):
     message_hashes = []
     for queue in Config.RABBITMQ_QUEUES:
@@ -42,7 +32,7 @@ def publish_bad_message(context):
     context.message_hashes = message_hashes
 
 
-@then('the hash of the bad message is seen multiple times')
+@then("each bad message is seen multiple times by the exception manager")
 def check_for_bad_messages(context):
     time.sleep(30)
     response = requests.get(f'{Config.EXCEPTION_MANAGER_URL}/badmessages/summary')

--- a/acceptance_tests/features/steps/bad_message.py
+++ b/acceptance_tests/features/steps/bad_message.py
@@ -1,0 +1,51 @@
+import hashlib
+import json
+import random
+import time
+
+import requests
+from behave import when, then, step
+
+from acceptance_tests.utilities.rabbit_context import RabbitContext
+from acceptance_tests.utilities.rabbit_helper import purge_queues
+from config import Config
+
+
+@step('queues are free of messages')
+def clear_queues(context):
+    purge_queues(*Config.RABBITMQ_QUEUES, 'delayedRedeliveryQueue', 'RM.Field')
+    time.sleep(5)
+    requests.get(f'{Config.EXCEPTION_MANAGER_URL}/reset')
+
+
+@when('a bad message is placed on each of the queues')
+def publish_bad_message(context):
+    message_hashes = []
+    for queue in Config.RABBITMQ_QUEUES:
+        message = json.dumps(
+            {
+                "message": "This is a dodgy message",
+                "queueName": queue,
+                "randomNumber": random.randint(1, 1000)
+            }
+        )
+
+        with RabbitContext(queue_name=queue) as rabbit:
+            rabbit.publish_message(
+                message=message,
+                content_type='application/json')
+
+        message_hashes.append(hashlib.sha256(message.encode('utf-8')).hexdigest())
+
+    context.message_hashes = message_hashes
+
+
+@then('the hash of the bad message is seen multiple times')
+def check_for_bad_messages(context):
+    time.sleep(20)
+    response = requests.get(f'{Config.EXCEPTION_MANAGER_URL}/badmessages/summary')
+    bad_messages = response.json()
+
+    for bad_message in bad_messages:
+        assert bad_message['seenCount'] > 1
+        assert bad_message['messageHash'] in context.message_hashes

--- a/acceptance_tests/features/steps/bad_message.py
+++ b/acceptance_tests/features/steps/bad_message.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
-import random
 import time
+import uuid
 import requests
 
 from behave import when, then, step
@@ -13,7 +13,9 @@ from config import Config
 
 @step('queues are free of messages')
 def clear_queues(context):
-    purge_queues(*Config.RABBITMQ_QUEUES, 'delayedRedeliveryQueue', 'RM.Field')
+    for i in range(0, 4):
+        purge_queues(*Config.RABBITMQ_QUEUES, 'delayedRedeliveryQueue', 'RM.Field')
+        time.sleep(1)
     time.sleep(5)
     requests.get(f'{Config.EXCEPTION_MANAGER_URL}/reset')
 
@@ -26,7 +28,7 @@ def publish_bad_message(context):
             {
                 "message": "This is a dodgy message",
                 "queueName": queue,
-                "randomNumber": random.randint(1, 1000)
+                "uniqueness": str(uuid.uuid4())
             }
         )
 
@@ -42,7 +44,7 @@ def publish_bad_message(context):
 
 @then('the hash of the bad message is seen multiple times')
 def check_for_bad_messages(context):
-    time.sleep(20)
+    time.sleep(30)
     response = requests.get(f'{Config.EXCEPTION_MANAGER_URL}/badmessages/summary')
     bad_messages = response.json()
 

--- a/acceptance_tests/features/steps/bad_message.py
+++ b/acceptance_tests/features/steps/bad_message.py
@@ -2,8 +2,8 @@ import hashlib
 import json
 import random
 import time
-
 import requests
+
 from behave import when, then, step
 
 from acceptance_tests.utilities.rabbit_context import RabbitContext

--- a/acceptance_tests/utilities/rabbit_context.py
+++ b/acceptance_tests/utilities/rabbit_context.py
@@ -1,4 +1,5 @@
 import pika
+from pika.spec import PERSISTENT_DELIVERY_MODE
 
 from acceptance_tests.utilities.exceptions import RabbitConnectionClosedError
 from config import Config
@@ -52,4 +53,4 @@ class RabbitContext:
             exchange=exchange or self._exchange,
             routing_key=routing_key or self.queue_name,
             body=message,
-            properties=pika.BasicProperties(content_type=content_type))
+            properties=pika.BasicProperties(content_type=content_type, delivery_mode=PERSISTENT_DELIVERY_MODE))

--- a/config.py
+++ b/config.py
@@ -80,3 +80,29 @@ class Config:
     NOTIFY_STUB_HOST = os.getenv('NOTIFY_STUB_HOST', 'localhost')
     NOTIFY_STUB_PORT = os.getenv('NOTIFY_STUB_PORT', '8917')
     NOTIFY_STUB_SERVICE = f'{PROTOCOL}://{NOTIFY_STUB_HOST}:{NOTIFY_STUB_PORT}'
+
+    EXCEPTIONMANAGER_CONNECTION_HOST = os.getenv('EXCEPTIONMANAGER_CONNECTION_HOST', 'localhost')
+    EXCEPTIONMANAGER_CONNECTION_PORT = os.getenv('EXCEPTIONMANAGER_CONNECTION_PORT', '8666')
+    EXCEPTION_MANAGER_URL = f'http://{EXCEPTIONMANAGER_CONNECTION_HOST}:{EXCEPTIONMANAGER_CONNECTION_PORT}'
+
+    RABBITMQ_QUEUES = ['Action.Field',
+                       'Case.Responses',
+                       'FieldworkAdapter.Refusals',
+                       'FieldworkAdapter.invalidAddress',
+                       'FieldworkAdapter.uacUpdated',
+                       'action.events',
+                       'action.fulfilment',
+                       'action.undeliveredMailQueue',
+                       'case.action',
+                       'case.ccsPropertyListedQueue',
+                       'case.fulfilments',
+                       'case.invalidAddressQueue',
+                       'case.questionnairelinked',
+                       'case.refusals',
+                       'case.sample.inbound',
+                       'case.uac-qid-created',
+                       'case.undeliveredMailQueue',
+                       'notify.enriched.fulfilment',
+                       'notify.fulfilments',
+                       'survey.launched',
+                       'unaddressedRequestQueue']

--- a/run_gke.sh
+++ b/run_gke.sh
@@ -66,6 +66,8 @@ kubectl run acceptance-tests -it --command --rm --quiet --generator=run-pod/v1 \
     --env=RABBITMQ_HTTP_PORT=15672 \
     --env=NOTIFY_STUB_HOST=notify-stub \
     --env=NOTIFY_STUB_PORT=80 \
+    --env=EXCEPTIONMANAGER_CONNECTION_HOST=exception-manager \
+    --env=EXCEPTIONMANAGER_CONNECTION_PORT=80 \
     -- /bin/bash -c "sleep 2; behave acceptance_tests/features --tags=~@local-docker"
 
 if [ -z "$QID_BATCH_BRANCH" ]; then

--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -60,6 +60,8 @@ run:
       --env=RABBITMQ_HTTP_PORT=15672 \
       --env=NOTIFY_STUB_HOST=notify-stub \
       --env=NOTIFY_STUB_PORT=80 \
+      --env=EXCEPTIONMANAGER_CONNECTION_HOST=exception-manager \
+      --env=EXCEPTIONMANAGER_CONNECTION_PORT=80 \
       -- /bin/bash -c "sleep 2; behave acceptance_tests/features --tags=~@local-docker"
 
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
A test has been added to check that bad messages are placed on the redelivery queue.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Test added for redelivery queue.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check this branch out and run it.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/L8zrPipS/316-automate-testing-of-rabbit-redelivery-dead-letter-exchange-8

# Screenshots (if appropriate):