### PR TITLE
Updating tests to pass after attribute errors in printfilsvc repo

### DIFF
--- a/acceptance_tests/features/steps/print_file.py
+++ b/acceptance_tests/features/steps/print_file.py
@@ -147,7 +147,7 @@ def _create_expected_manifest(sftp_utility, csv_file, created_datetime, pack_cod
 
     _file = dict(
         sizeBytes=str(expected_size),
-        md5Sum=md5_hash,
+        md5sum=md5_hash,
         relativePath='./',
         name=csv_file.filename
     )


### PR DESCRIPTION
# Motivation and Context
Needed to make two typo changes in print-file-service to align with manifest in supplier files. Acceptance tests then needed to be altered in order to pass.

# What has changed
'md5Sum' changed to 'md5sum' in acceptance_tests/features/stepsprint_file.py

# How to test?
Run acceptance tests based on changes to this repo and census-rm-print-file-service

# Links
https://trello.com/c/BWR2j88I
