### PR TITLE
Added Action.Printer to queues to test

### DIFF
--- a/config.py
+++ b/config.py
@@ -86,6 +86,7 @@ class Config:
     EXCEPTION_MANAGER_URL = f'http://{EXCEPTIONMANAGER_CONNECTION_HOST}:{EXCEPTIONMANAGER_CONNECTION_PORT}'
 
     RABBITMQ_QUEUES = ['Action.Field',
+                       'Action.Printer',
                        'Case.Responses',
                        'FieldworkAdapter.Refusals',
                        'FieldworkAdapter.invalidAddress',


### PR DESCRIPTION
# Motivation and Context
As part of changing the printfile service to reject messages onto the redelivered queue. We can now add the Action.Printer queue to the list of queues that get tested with bad messages
# What has changed
- Added Action.Printer queue to queue config list

# How to test?
- Run with [Printfile service PR](https://github.com/ONSdigital/census-rm-print-file-service/pull/23)
- Run tests
# Links
[Trello](https://trello.com/c/ldIswXNl)
