### PR TITLE
Replace all bare asserts with test helper asserts

### DIFF
--- a/acceptance_tests/features/steps/ad_hoc_uac_qid.py
+++ b/acceptance_tests/features/steps/ad_hoc_uac_qid.py
@@ -5,6 +5,7 @@ import requests
 from behave import then, when, step
 
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context
+from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 caseapi_uacqid_pair_url = f'{Config.CASEAPI_SERVICE}/uacqid/create'
@@ -21,11 +22,12 @@ def generate_post_request_body(context, questionnaire_type):
 
 @then('case API should return a  new UAC and QID with correct questionnaire type')
 def generate_uacqid_pair(context):
-    assert context.response.status_code == 201
+    test_helper.assertEqual(context.response.status_code, 201)
     response_data = json.loads(context.response.content)
-    assert 'uac' in response_data, 'uac missing in response'
-    assert 'qid' in response_data, 'qid missing in response'
-    assert context.uacqid_json["questionnaireType"] == response_data['qid'][:2]
+    test_helper.assertIn('uac', response_data, 'uac missing in response')
+    test_helper.assertIn('qid', response_data, 'qid missing in response')
+    test_helper.assertEqual(context.uacqid_json["questionnaireType"], response_data['qid'][:2],
+                            'Questionnaire type did not match')
 
 
 @step('a UAC updated message with "{questionnaire_type}" questionnaire type is emitted')
@@ -36,9 +38,9 @@ def listen_for_ad_hoc_uac_updated_message(context, questionnaire_type):
                                                       expected_msg_count=1,
                                                       type_filter='UAC_UPDATED'))
     uac_updated_event = context.messages_received[0]
-    assert uac_updated_event['payload']['uac']['caseId'] == context.first_case['id'], \
-        'Fulfilment request UAC updated event found with wrong case ID'
-    assert uac_updated_event['payload']['uac']['questionnaireId'].startswith(questionnaire_type), \
-        'Fulfilment request UAC updated event found with wrong questionnaire type'
+    test_helper.assertEqual(uac_updated_event['payload']['uac']['caseId'], context.first_case['id'],
+                            'Fulfilment request UAC updated event found with wrong case ID')
+    test_helper.assertTrue(uac_updated_event['payload']['uac']['questionnaireId'].startswith(questionnaire_type),
+                           'Fulfilment request UAC updated event found with wrong questionnaire type')
     context.requested_uac = uac_updated_event['payload']['uac']['uac']
     context.requested_qid = uac_updated_event['payload']['uac']['questionnaireId']

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -4,6 +4,7 @@ import requests
 from behave import step
 
 from acceptance_tests.utilities.rabbit_context import RabbitContext
+from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
@@ -47,4 +48,4 @@ def check_case_events(context):
     for case_event in response_json['caseEvents']:
         if case_event['description'] == 'Invalid address':
             return
-    assert False
+    test_helper.fail('Did not find expected invalid address event')

--- a/acceptance_tests/features/steps/bad_message.py
+++ b/acceptance_tests/features/steps/bad_message.py
@@ -2,11 +2,12 @@ import hashlib
 import json
 import time
 import uuid
-import requests
 
+import requests
 from behave import then, given
 
 from acceptance_tests.utilities.rabbit_context import RabbitContext
+from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
@@ -39,5 +40,7 @@ def check_for_bad_messages(context):
     bad_messages = response.json()
 
     for bad_message in bad_messages:
-        assert bad_message['seenCount'] > 1
-        assert bad_message['messageHash'] in context.message_hashes
+        test_helper.assertGreater(bad_message['seenCount'], 1,
+                                  msg=f'Seen count is not greater than 1, failed bad message summary: {bad_message}')
+        test_helper.assertIn(bad_message['messageHash'], context.message_hashes,
+                             msg=f'Unknown bad message hash, message summary: {bad_message}')

--- a/acceptance_tests/features/steps/case_events.py
+++ b/acceptance_tests/features/steps/case_events.py
@@ -17,7 +17,7 @@ def gather_messages_emitted_with_qids(context, questionnaire_types):
                                     functools.partial(store_all_msgs_in_context, context=context,
                                                       expected_msg_count=len(context.sample_units),
                                                       type_filter='CASE_CREATED'))
-    assert len(context.messages_received) == len(context.sample_units)
+    test_helper.assertEqual(len(context.messages_received), len(context.sample_units))
     context.case_created_events = context.messages_received.copy()
     _test_cases_correct(context)
     context.messages_received = []
@@ -27,7 +27,7 @@ def gather_messages_emitted_with_qids(context, questionnaire_types):
                                     functools.partial(store_all_msgs_in_context, context=context,
                                                       expected_msg_count=len(context.expected_uacs_cases),
                                                       type_filter='UAC_UPDATED'))
-    assert len(context.messages_received) == len(context.expected_uacs_cases)
+    test_helper.assertEqual(len(context.messages_received), len(context.expected_uacs_cases))
     context.uac_created_events = context.messages_received.copy()
     _test_uacs_correct(context)
     context.messages_received = []
@@ -39,7 +39,7 @@ def gather_uac_updated_events(context, number_of_matching_cases):
                                     functools.partial(store_all_msgs_in_context, context=context,
                                                       expected_msg_count=number_of_matching_cases,
                                                       type_filter='UAC_UPDATED'))
-    assert len(context.messages_received) == number_of_matching_cases
+    test_helper.assertEqual(len(context.messages_received), number_of_matching_cases)
     context.reminder_uac_updated_events = context.messages_received.copy()
     context.reminder_case_ids = {uac['payload']['uac']['caseId'] for uac in context.reminder_uac_updated_events}
     context.messages_received = []
@@ -88,7 +88,7 @@ def _test_cases_correct(context):
                 del context.expected_sample_units[index]
                 break
         else:
-            test_helper.fail(msg='Could not find sample unit')
+            test_helper.fail('Could not find sample unit')
 
 
 def _sample_matches_rh_message(sample_unit, rh_message):
@@ -100,7 +100,7 @@ def _sample_matches_rh_message(sample_unit, rh_message):
 
 
 def _test_uacs_correct(context):
-    assert len(context.messages_received) == len(context.expected_uacs_cases)
+    test_helper.assertEqual(len(context.messages_received), len(context.expected_uacs_cases))
 
     for msg in context.uac_created_events:
         _validate_uac_message(msg)
@@ -112,7 +112,7 @@ def _test_uacs_correct(context):
                 del context.expected_uacs_cases[index]
                 break
         else:
-            assert False, 'Could not find UAC Updated event'
+            test_helper.fail('Could not find UAC Updated event')
 
 
 def _validate_uac_message(parsed_body):

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -60,12 +60,12 @@ def find_multiple_cases_by_uprn(context):
 
     response_data = json.loads(response.content)
 
-    assert len(response_data) > 1, 'Multiple cases not found'
+    test_helper.assertGreater(len(response_data), 1, 'Multiple cases not found')
     # Check some of the fields aren't blank
     for case in response_data:
-        assert case['id'], 'caseId missing'
-        assert case['caseRef'], 'caseRef missing'
-        assert case['postcode'], 'postcode missing'
+        test_helper.assertTrue(case['id'], 'caseId missing')
+        test_helper.assertTrue(case['caseRef'], 'caseRef missing')
+        test_helper.assertTrue(case['postcode'], 'postcode missing')
 
 
 @then('a case can be retrieved by its caseRef')
@@ -89,60 +89,60 @@ def get_ccs_qid_for_case_id(context):
 
 @step('it contains the correct fields for a CENSUS case')
 def check_census_case_fields(context):
-    assert context.case_details['caseRef']
-    assert context.case_details['arid']
-    assert context.case_details['estabArid']
-    assert context.case_details['estabType']
-    assert context.case_details['uprn']
-    assert context.case_details['collectionExerciseId']
+    test_helper.assertTrue(context.case_details['caseRef'])
+    test_helper.assertTrue(context.case_details['arid'])
+    test_helper.assertTrue(context.case_details['estabArid'])
+    test_helper.assertTrue(context.case_details['estabType'])
+    test_helper.assertTrue(context.case_details['uprn'])
+    test_helper.assertTrue(context.case_details['collectionExerciseId'])
+    test_helper.assertTrue(context.case_details['createdDateTime'])
+    test_helper.assertTrue(context.case_details['addressLine1'])
+    test_helper.assertTrue(context.case_details['addressLine2'])
+    test_helper.assertTrue(context.case_details['addressLine3'])
+    test_helper.assertTrue(context.case_details['townName'])
+    test_helper.assertTrue(context.case_details['postcode'])
+    test_helper.assertTrue(context.case_details['addressLevel'])
+    test_helper.assertTrue(context.case_details['abpCode'])
+    test_helper.assertTrue(context.case_details['region'])
+    test_helper.assertTrue(context.case_details['latitude'])
+    test_helper.assertTrue(context.case_details['longitude'])
+    test_helper.assertTrue(context.case_details['oa'])
+    test_helper.assertTrue(context.case_details['lsoa'])
+    test_helper.assertTrue(context.case_details['msoa'])
+    test_helper.assertTrue(context.case_details['lad'])
+    test_helper.assertTrue(context.case_details['state'])
+    test_helper.assertTrue(context.case_details['id'])
+    test_helper.assertTrue(context.case_details['caseType'])
     test_helper.assertEqual(context.case_details['surveyType'], "CENSUS")
-    assert context.case_details['createdDateTime']
-    assert context.case_details['addressLine1']
-    assert context.case_details['addressLine2']
-    assert context.case_details['addressLine3']
-    assert context.case_details['townName']
-    assert context.case_details['postcode']
-    assert context.case_details['addressLevel']
-    assert context.case_details['abpCode']
-    assert context.case_details['region']
-    assert context.case_details['latitude']
-    assert context.case_details['longitude']
-    assert context.case_details['oa']
-    assert context.case_details['lsoa']
-    assert context.case_details['msoa']
-    assert context.case_details['lad']
-    assert context.case_details['state']
-    assert context.case_details['id']
-    assert context.case_details['caseType']
 
 
 @step('it contains the correct fields for a CCS case')
 def check_ccs_case_fields(context):
-    assert context.ccs_case['caseRef']
+    test_helper.assertTrue(context.ccs_case['caseRef'])
     test_helper.assertFalse(context.ccs_case['arid'])
     test_helper.assertFalse(context.ccs_case['estabArid'])
-    assert context.ccs_case['estabType']
+    test_helper.assertTrue(context.ccs_case['estabType'])
     test_helper.assertFalse(context.ccs_case['uprn'])
-    assert context.ccs_case['collectionExerciseId']
+    test_helper.assertTrue(context.ccs_case['collectionExerciseId'])
     test_helper.assertEqual(context.ccs_case['surveyType'], "CCS")
-    assert context.ccs_case['createdDateTime']
-    assert context.ccs_case['addressLine1']
-    assert context.ccs_case['addressLine2']
-    assert context.ccs_case['addressLine3']
-    assert context.ccs_case['townName']
-    assert context.ccs_case['postcode']
-    assert context.ccs_case['addressLevel']
+    test_helper.assertTrue(context.ccs_case['createdDateTime'])
+    test_helper.assertTrue(context.ccs_case['addressLine1'])
+    test_helper.assertTrue(context.ccs_case['addressLine2'])
+    test_helper.assertTrue(context.ccs_case['addressLine3'])
+    test_helper.assertTrue(context.ccs_case['townName'])
+    test_helper.assertTrue(context.ccs_case['postcode'])
+    test_helper.assertTrue(context.ccs_case['addressLevel'])
     test_helper.assertFalse(context.ccs_case['abpCode'])
     test_helper.assertFalse(context.ccs_case['region'])
-    assert context.ccs_case['latitude']
-    assert context.ccs_case['longitude']
+    test_helper.assertTrue(context.ccs_case['latitude'])
+    test_helper.assertTrue(context.ccs_case['longitude'])
     test_helper.assertFalse(context.ccs_case['oa'])
     test_helper.assertFalse(context.ccs_case['lsoa'])
     test_helper.assertFalse(context.ccs_case['msoa'])
     test_helper.assertFalse(context.ccs_case['lad'])
-    assert context.ccs_case['state']
-    assert context.ccs_case['id']
-    assert context.ccs_case['caseType']
+    test_helper.assertTrue(context.ccs_case['state'])
+    test_helper.assertTrue(context.ccs_case['id'])
+    test_helper.assertTrue(context.ccs_case['caseType'])
 
 
 def get_logged_events_for_case_by_id(case_id):

--- a/acceptance_tests/features/steps/field_reminder.py
+++ b/acceptance_tests/features/steps/field_reminder.py
@@ -39,7 +39,7 @@ def fieldwork_message_callback(ch, method, _properties, body, context):
             ch.basic_ack(delivery_tag=method.delivery_tag)
             break
     else:
-        test_helper.fail(msg='Found message on Action.Field case queue which did not match any expected sample units')
+        test_helper.fail('Found message on Action.Field case queue which did not match any expected sample units')
 
     if not context.expected_cases_for_action:
         ch.stop_consuming()

--- a/acceptance_tests/features/steps/print_file.py
+++ b/acceptance_tests/features/steps/print_file.py
@@ -114,7 +114,7 @@ def _check_manifest_files_created(context, pack_code):
                 manifest_file = _get_matching_manifest_file(csv_file.filename, files)
 
                 if manifest_file is None:
-                    assert False, f'Failed to find manifest file for {csv_file.filename}'
+                    test_helper.fail(f'Failed to find manifest file for {csv_file.filename}')
 
                 actual_manifest = _get_actual_manifest(sftp_utility, manifest_file, pack_code)
                 creation_datetime = actual_manifest['manifestCreated']

--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -8,6 +8,7 @@ from acceptance_tests.features.steps.event_log import check_if_event_list_is_exa
 from acceptance_tests.features.steps.receipt import _field_work_receipt_callback
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue
+from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
@@ -68,7 +69,7 @@ def check_case_events(context):
     for case_event in response_json['caseEvents']:
         if case_event['description'] == 'Refusal Received':
             return
-    assert False
+    test_helper.fail('Did not find "Refusal Received" event')
 
 
 @step('an action instruction cancel message is emitted to FWMT')
@@ -77,8 +78,8 @@ def refusal_received(context):
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE_TEST,
                                     functools.partial(_field_work_receipt_callback, context=context))
 
-    assert context.fwmt_emitted_case_id == context.refused_case_id
-    assert context.addressType == 'HH'
+    test_helper.assertEqual(context.fwmt_emitted_case_id, context.refused_case_id)
+    test_helper.assertEqual(context.addressType, 'HH')
 
 
 @step("the events logged for the refusal case are {expected_event_list}")

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -76,7 +76,7 @@ def check_uac_message_is_received(context):
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE_TEST,
                                     functools.partial(_uac_callback, context=context))
 
-    assert context.expected_message_received
+    test_helper.assertTrue(context.expected_message_received)
 
 
 @step("a Questionnaire Linked event is logged")
@@ -92,13 +92,13 @@ def check_question_linked_event_is_logged(context):
     for case_event in response_json['caseEvents']:
         if case_event['description'] == 'Questionnaire Linked':
             return
-    assert False
+    test_helper.fail('Did not find questionnaire linked event')
 
 
 @retry(stop_max_attempt_number=10, wait_fixed=1000)
 def get_case_id_by_questionnaire_id(questionnaire_id):
     response = requests.get(f'{caseapi_url}/qid/{questionnaire_id}')
-    assert response.status_code == 200, "Unexpected status code"
+    test_helper.assertEqual(response.status_code, 200, "Unexpected status code")
     response_json = response.json()
     return response_json['id']
 
@@ -153,13 +153,13 @@ def validate_unaddressed_print_file(context):
              'eu.gcr.io/census-rm-ci/rm/census-rm-qid-batch-runner', '/app/run_acceptance_tests.sh'],
             check=True)
     except subprocess.CalledProcessError:
-        raise AssertionError('Unaddressed print file test failed')
+        test_helper.fail('Unaddressed print file test failed')
 
 
 @step("a receipt for the unlinked UAC-QID pair is received")
 def send_receipt_for_unaddressed(context):
     _publish_offline_receipt(context, questionnaire_id=context.expected_questionnaire_id)
-    assert context.sent_to_gcp
+    test_helper.assertTrue(context.sent_to_gcp)
 
 
 @then("message redelivery does not go bananas")

--- a/acceptance_tests/utilities/print_file_helper.py
+++ b/acceptance_tests/utilities/print_file_helper.py
@@ -89,7 +89,7 @@ def _add_expected_uac_data(message, expected_data):
         expected_data[case_id]['uac_wales'] = uac_payload['uac']
         expected_data[case_id]['qid_wales'] = uac_payload['questionnaireId']
     else:
-        assert False, "Unexpected questionnaire type"
+        test_helper.fail('Unexpected questionnaire type')
 
     return expected_data
 

--- a/acceptance_tests/utilities/rabbit_helper.py
+++ b/acceptance_tests/utilities/rabbit_helper.py
@@ -5,6 +5,7 @@ import logging
 from structlog import wrap_logger
 
 from acceptance_tests.utilities.rabbit_context import RabbitContext
+from acceptance_tests.utilities.test_case_helper import test_helper
 
 logger = wrap_logger(logging.getLogger(__name__))
 
@@ -26,7 +27,7 @@ def start_listening_to_rabbit_queue(queue, on_message_callback, timeout=30):
 def _timeout_callback(rabbit):
     logger.error('Timed out waiting for messages')
     rabbit.close_connection()
-    assert False, "Didn't find the expected number of messages"
+    test_helper.fail("Didn't find the expected number of messages")
 
 
 def store_all_msgs_in_context(ch, method, _properties, body, context, expected_msg_count, type_filter=None):


### PR DESCRIPTION
# Motivation and Context
The behave docs do recommend using bare `assert`'s which we have in a lot of places now, but we have found this makes the test failures very opaque as it does not log the values which failed the assertion. Our `test_helper` lets us use python `unittest` assertion methods which do some extra logging, giving us much more informative test failures.

# What has changed
* Replace all bare asserts with test helper asserts

# How to test?
Run the tests, what they are testing should not have changed but if you induce a failure you should see more helpful logging.

# Links
https://trello.com/c/Pl2K49Zv/431-use-assertion-helpers-in-acceptance-tests