### PR TITLE
RMC-335 Telephone capture for HH cases

### DIFF
--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -1,11 +1,14 @@
+import functools
+
 import requests
 from behave import step
 
+from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-@step("there is a request for telephone capture for an english respondent with case type HH")
+@step('there is a request for telephone capture for an english respondent with case type HH')
 def request_telephone_capture_qid_uac(context):
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
     response = requests.get(f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid")
@@ -14,7 +17,25 @@ def request_telephone_capture_qid_uac(context):
     context.telephone_capture_qid_uac = response.json()
 
 
-@step("generate and return a UAC and the correct english HH QID type")
-def check_telephone_capture_uac_and_qid_type(context):
+@step('a UAC and QID with questionnaire type "{questionnaire_type}" type are generated and returned')
+def check_telephone_capture_uac_and_qid_type(context, questionnaire_type):
     test_helper.assertIsNotNone(context.telephone_capture_qid_uac.get('uac'))
-    test_helper.assertEqual(context.telephone_capture_qid_uac['questionnaireId'][:2], '01')
+    test_helper.assertEqual(context.telephone_capture_qid_uac['questionnaireId'][:2], questionnaire_type)
+
+
+@step('a UAC updated message linking the new UAC and QID to the requested case is emitted')
+def check_correct_uac_updated_message_is_emitted(context):
+    context.messages_received = []
+    start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE_TEST,
+                                    functools.partial(store_all_msgs_in_context, context=context,
+                                                      expected_msg_count=1,
+                                                      type_filter='UAC_UPDATED'))
+
+    uac_updated_payload = context.messages_received[0]['payload']['uac']
+    test_helper.assertEqual(uac_updated_payload['caseId'], context.first_case['id'],
+                            'UAC updated event case ID does not match the case it was requested for')
+    test_helper.assertEqual(uac_updated_payload['uac'], context.telephone_capture_qid_uac['uac'],
+                            'UAC updated event UAC does not match what the API returned')
+    test_helper.assertEqual(uac_updated_payload['questionnaireId'],
+                            context.telephone_capture_qid_uac['questionnaireId'],
+                            'UAC updated event QID does not match what the API returned')

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -4,13 +4,11 @@ from behave import step
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
-case_api_url = f'{Config.CASEAPI_SERVICE}/cases/'
-
 
 @step("there is a request for telephone capture for an english respondent with case type HH")
 def request_telephone_capture_qid_uac(context):
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
-    response = requests.get(f"{case_api_url}{context.first_case['id']}/qid")
+    response = requests.get(f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid")
     test_helper.assertEqual(response.status_code, 200)
 
     context.telephone_capture_qid_uac = response.json()

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -23,7 +23,7 @@ def check_telephone_capture_uac_and_qid_type(context, questionnaire_type):
     test_helper.assertEqual(context.telephone_capture_qid_uac['questionnaireId'][:2], questionnaire_type)
 
 
-@step('a UAC updated message linking the new UAC and QID to the requested case is emitted')
+@step('a UAC updated event is emitted linking the new UAC and QID to the requested case')
 def check_correct_uac_updated_message_is_emitted(context):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE_TEST,

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -1,0 +1,22 @@
+import requests
+from behave import step
+
+from acceptance_tests.utilities.test_case_helper import test_helper
+from config import Config
+
+case_api_url = f'{Config.CASEAPI_SERVICE}/cases/'
+
+
+@step("there is a request for telephone capture for an english respondent with case type HH")
+def request_telephone_capture_qid_uac(context):
+    context.first_case = context.case_created_events[0]['payload']['collectionCase']
+    response = requests.get(f"{case_api_url}{context.first_case['id']}/qid")
+    test_helper.assertEqual(response.status_code, 200)
+
+    context.telephone_capture_qid_uac = response.json()
+
+
+@step("generate and return a UAC and the correct english HH QID type")
+def check_telephone_capture_uac_and_qid_type(context):
+    test_helper.assertIsNotNone(context.telephone_capture_qid_uac.get('uac'))
+    test_helper.assertEqual(context.telephone_capture_qid_uac['questionnaireId'][:2], '01')

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -1,0 +1,10 @@
+Feature: Telephone capture
+  As a respondent
+  I want to be able to complete my response over the phone
+  So that I can respond in the way I choose
+
+  Scenario: Generate correct QID type
+    Given sample file "sample_1_english_unit.csv" is loaded successfully
+    When there is a request for telephone capture for an english respondent with case type HH
+    Then generate and return a UAC and the correct english HH QID type
+    And a UAC updated message with "01" questionnaire type is emitted

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -7,4 +7,4 @@ Feature: Telephone capture
     Given sample file "sample_1_english_unit.csv" is loaded successfully
     When there is a request for telephone capture for an english respondent with case type HH
     Then a UAC and QID with questionnaire type "01" type are generated and returned
-    And a UAC updated message linking the new UAC and QID to the requested case is emitted
+    And a UAC updated event is emitted linking the new UAC and QID to the requested case

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -6,5 +6,5 @@ Feature: Telephone capture
   Scenario: Generate correct QID type
     Given sample file "sample_1_english_unit.csv" is loaded successfully
     When there is a request for telephone capture for an english respondent with case type HH
-    Then generate and return a UAC and the correct english HH QID type
-    And a UAC updated message with "01" questionnaire type is emitted
+    Then a UAC and QID with questionnaire type "01" type are generated and returned
+    And a UAC updated message linking the new UAC and QID to the requested case is emitted


### PR DESCRIPTION
# Motivation and Context
Telephone capture requires an endpoint to synchronously generate and return a new UAC/QID pair for a specified case. This new UAC/QID link also needs to be sent to the case processor for eventual data consistency. This is the same pattern as the existing UAC/QID endpoint but the caller only specifies a case ID and the service must work out the appropriate questionnaire type to request. This PR only implements the feature for HH household cases.

# What has changed
* Add feature and scenario for household case telephone capture

# How to test?
Build and run linked case API branch with docker dev or in a cloud environment, run these tests.

# Links
https://trello.com/c/J4Lo1jJl/464-rmc-335-telephone-capture-hh-8#
https://github.com/ONSdigital/census-rm-case-api/pull/45