### PR TITLE
check CE fields emitted correctly

### DIFF
--- a/acceptance_tests/features/field_reminder.feature
+++ b/acceptance_tests/features/field_reminder.feature
@@ -10,4 +10,4 @@ Feature: Reminder messages are emitted to Field Work Management Tool
   Scenario: send community estab cases to field
     Given sample file "sample_for_ce_stories.csv" is loaded successfully
     When an action rule for community estabs is set 5 seconds in the future
-    Then the action instruction emitted to FWMT where case has a "caseType" of "CE" and CEComplete is "false"
+    Then the action instruction is emitted to FWMT where case has a "caseType" of "CE" and CEComplete is "false"

--- a/acceptance_tests/features/field_reminder.feature
+++ b/acceptance_tests/features/field_reminder.feature
@@ -10,4 +10,4 @@ Feature: Reminder messages are emitted to Field Work Management Tool
   Scenario: send community estab cases to field
     Given sample file "sample_for_ce_stories.csv" is loaded successfully
     When an action rule for community estabs is set 5 seconds in the future
-    Then the action instruction messages are emitted to FWMT where the case has a "caseType" of "CE"
+    Then action instruction emitted to FWMT where case has a "caseType" of "CE" and CEComplete is "false"

--- a/acceptance_tests/features/field_reminder.feature
+++ b/acceptance_tests/features/field_reminder.feature
@@ -10,4 +10,4 @@ Feature: Reminder messages are emitted to Field Work Management Tool
   Scenario: send community estab cases to field
     Given sample file "sample_for_ce_stories.csv" is loaded successfully
     When an action rule for community estabs is set 5 seconds in the future
-    Then action instruction emitted to FWMT where case has a "caseType" of "CE" and CEComplete is "false"
+    Then the action instruction emitted to FWMT where case has a "caseType" of "CE" and CEComplete is "false"

--- a/acceptance_tests/features/steps/field_reminder.py
+++ b/acceptance_tests/features/steps/field_reminder.py
@@ -11,13 +11,24 @@ from config import Config
 @step('the action instruction messages for only the HH case are emitted to FWMT where the case has a "{filter_column}" '
       'of "{treatment_code}"')
 @step(
-    'the action instruction messages are emitted to FWMT where the case has a "{filter_column}" of "{treatment_code}"')
-def fwmt_messages_received(context, filter_column, treatment_code):
+    'the action instruction messages are emitted to FWMT where the case has a "{filter_column}" of "{expected_value}"')
+def fwmt_messages_received(context, filter_column, expected_value):
+    _check_emitted_action_instructions(context, filter_column, expected_value, 'false')
+
+
+@step('action instruction emitted to FWMT where case has a "{filter_column}" of "{expected_value}" and CEComplete '
+      'is "{expected_ce1_complete}"')
+def fwmt_message_recived_with_ce1_complete(context, filter_column, expected_value, expected_ce1_complete):
+    _check_emitted_action_instructions(context, filter_column, expected_value, expected_ce1_complete)
+
+
+def _check_emitted_action_instructions(context, filter_column, treatment_code, expected_ce1_complete):
     context.expected_cases_for_action = [
         case_created['payload']['collectionCase'] for case_created in context.case_created_events
         if case_created['payload']['collectionCase'][filter_column] == treatment_code
     ]
     context.fieldwork_case_ids = [case['id'] for case in context.expected_cases_for_action]
+    context.expected_ce1_complete = expected_ce1_complete
 
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE_TEST,
                                     functools.partial(fieldwork_message_callback, context=context))
@@ -35,9 +46,10 @@ def fieldwork_message_callback(ch, method, _properties, body, context):
 
     for index, case in enumerate(context.expected_cases_for_action):
         if _message_matches(case, action_instruction):
-            _message_valid(case, action_instruction)
+            _message_valid(case, action_instruction, context.expected_ce1_complete)
             del context.expected_cases_for_action[index]
             ch.basic_ack(delivery_tag=method.delivery_tag)
+
             break
     else:
         test_helper.fail('Found message on Action.Field case queue which did not match any expected sample units')
@@ -50,7 +62,7 @@ def _message_matches(case, action_instruction):
     return action_instruction.find('.//caseId').text == case['id']
 
 
-def _message_valid(case, action_instruction):
+def _message_valid(case, action_instruction, ce1_complete_expected):
     test_helper.assertEqual(case['address']['latitude'], action_instruction.find('.//latitude').text)
     test_helper.assertEqual(case['address']['longitude'], action_instruction.find('.//longitude').text)
     test_helper.assertEqual(case['address']['postcode'], action_instruction.find('.//postcode').text)
@@ -59,3 +71,4 @@ def _message_valid(case, action_instruction):
     test_helper.assertEqual('CENSUS', action_instruction.find('.//surveyName').text)
     test_helper.assertEqual(case['address']['estabType'], action_instruction.find('.//estabType').text)
     test_helper.assertEqual(case['address']['arid'], action_instruction.find('.//arid').text)
+    test_helper.assertEquals(ce1_complete_expected, action_instruction.find('.//ceCE1Complete').text)

--- a/acceptance_tests/features/steps/field_reminder.py
+++ b/acceptance_tests/features/steps/field_reminder.py
@@ -9,7 +9,7 @@ from config import Config
 
 
 @step('the action instruction messages for only the HH case are emitted to FWMT where the case has a "{filter_column}" '
-      'of "{treatment_code}"')
+      'of "{expected_value}"')
 @step(
     'the action instruction messages are emitted to FWMT where the case has a "{filter_column}" of "{expected_value}"')
 def fwmt_messages_received(context, filter_column, expected_value):
@@ -72,3 +72,5 @@ def _message_valid(case, action_instruction, ce1_complete_expected):
     test_helper.assertEqual(case['address']['estabType'], action_instruction.find('.//estabType').text)
     test_helper.assertEqual(case['address']['arid'], action_instruction.find('.//arid').text)
     test_helper.assertEquals(ce1_complete_expected, action_instruction.find('.//ceCE1Complete').text)
+    test_helper.assertEquals(case['ceExpectedCapacity'], int(action_instruction.find('.//ceExpectedResponses').text))
+    test_helper.assertEquals(case['ceActualResponses'], int(action_instruction.find('.//ceActualResponses').text))

--- a/acceptance_tests/features/steps/field_reminder.py
+++ b/acceptance_tests/features/steps/field_reminder.py
@@ -16,8 +16,8 @@ def fwmt_messages_received(context, filter_column, expected_value):
     _check_emitted_action_instructions(context, filter_column, expected_value, 'false')
 
 
-@step('the action instruction emitted to FWMT where case has a "{filter_column}" of "{expected_value}" and CEComplete '
-      'is "{expected_ce1_complete}"')
+@step('the action instruction is emitted to FWMT where case has a "{filter_column}" of "{expected_value}" '
+      'and CEComplete is "{expected_ce1_complete}"')
 def fwmt_message_recived_with_ce1_complete(context, filter_column, expected_value, expected_ce1_complete):
     _check_emitted_action_instructions(context, filter_column, expected_value, expected_ce1_complete)
 

--- a/acceptance_tests/features/steps/field_reminder.py
+++ b/acceptance_tests/features/steps/field_reminder.py
@@ -16,7 +16,7 @@ def fwmt_messages_received(context, filter_column, expected_value):
     _check_emitted_action_instructions(context, filter_column, expected_value, 'false')
 
 
-@step('action instruction emitted to FWMT where case has a "{filter_column}" of "{expected_value}" and CEComplete '
+@step('the action instruction emitted to FWMT where case has a "{filter_column}" of "{expected_value}" and CEComplete '
       'is "{expected_ce1_complete}"')
 def fwmt_message_recived_with_ce1_complete(context, filter_column, expected_value, expected_ce1_complete):
     _check_emitted_action_instructions(context, filter_column, expected_value, expected_ce1_complete)


### PR DESCRIPTION
# Motivation and Context
Check ce1Complete is set, as was coming through as null sometimes

# What has changed
Now tests for ce1Complete

# How to test?
Run with master except the new fieldworkAdapter branch: https://github.com/ONSdigital/census-rm-fieldwork-adapter/pull/25

# Links
https://trello.com/c/gIGqWwlV/493-fixes-to-ce