### PR TITLE
RMC-335 Telephone Capture HI

### DIFF
--- a/acceptance_tests/features/fulfilment_request.feature
+++ b/acceptance_tests/features/fulfilment_request.feature
@@ -11,7 +11,7 @@ Feature: Handle fulfilment request events
     Given sample file "sample_input_england_census_spec.csv" is loaded
     And messages are emitted to RH and Action Scheduler with [01] questionnaire types
     When a UAC fulfilment request "UACIT1" message for a created case is sent
-    Then a new child case is emitted to RH and Action Scheduler
+    Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
     And notify api was called with template id "21447bc2-e7c7-41ba-8c5e-7a5893068525"
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
     And the individual case has these events logged [RM_UAC_CREATED]
@@ -69,7 +69,7 @@ Feature: Handle fulfilment request events
     Given sample file "sample_1_english_unit.csv" is loaded
     And messages are emitted to RH and Action Scheduler with [01] questionnaire types
     When an individual print fulfilment request "<fulfilment code>" is received by RM
-    Then a new child case is emitted to RH and Action Scheduler
+    Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
     And correctly formatted individual response questionnaires are are created with "<fulfilment code>"
     And the fulfilment request event is logged
 

--- a/acceptance_tests/features/steps/sample.py
+++ b/acceptance_tests/features/steps/sample.py
@@ -1,21 +1,17 @@
 import json
+from pathlib import Path
 
 from behave import step
 from load_sample import load_sample_file
 
-from acceptance_tests.features.steps.case_events import get_cases_and_uac_event_messages
+from acceptance_tests.utilities.event_helper import get_and_check_case_created_messages, \
+    get_and_check_uac_updated_messages
 from config import Config
 
 
 @step('sample file "{sample_file_name}" is loaded')
 def load_sample_file_step(context, sample_file_name):
-    sample_file_name = f'./resources/sample_files/{sample_file_name}'
-
-    sample_units_raw = load_sample_file(sample_file_name, context.collection_exercise_id, context.action_plan_id,
-                                        host=Config.RABBITMQ_HOST, port=Config.RABBITMQ_PORT,
-                                        vhost=Config.RABBITMQ_VHOST, exchange=Config.RABBITMQ_EXCHANGE,
-                                        user=Config.RABBITMQ_USER, password=Config.RABBITMQ_PASSWORD,
-                                        queue_name=Config.RABBITMQ_SAMPLE_INBOUND_QUEUE)
+    sample_units_raw = _load_sample(context, sample_file_name)
 
     context.sample_units = [
         json.loads(sample_unit)
@@ -25,17 +21,21 @@ def load_sample_file_step(context, sample_file_name):
 
 @step('sample file "{sample_file_name}" is loaded successfully')
 def load_sample_file_successfully_step(context, sample_file_name):
-    sample_file_name = f'./resources/sample_files/{sample_file_name}'
-
-    sample_units_raw = load_sample_file(sample_file_name, context.collection_exercise_id, context.action_plan_id,
-                                        host=Config.RABBITMQ_HOST, port=Config.RABBITMQ_PORT,
-                                        vhost=Config.RABBITMQ_VHOST, exchange=Config.RABBITMQ_EXCHANGE,
-                                        user=Config.RABBITMQ_USER, password=Config.RABBITMQ_PASSWORD,
-                                        queue_name=Config.RABBITMQ_SAMPLE_INBOUND_QUEUE)
+    sample_units_raw = _load_sample(context, sample_file_name)
 
     context.sample_units = [
         json.loads(sample_unit)
         for sample_unit in sample_units_raw.values()
     ]
 
-    get_cases_and_uac_event_messages(context)
+    get_and_check_case_created_messages(context)
+    get_and_check_uac_updated_messages(context)
+
+
+def _load_sample(context, sample_file_name):
+    sample_file_path = Path(__file__).parents[3].joinpath('resources', 'sample_files', sample_file_name)
+    return load_sample_file(sample_file_path, context.collection_exercise_id, context.action_plan_id,
+                            host=Config.RABBITMQ_HOST, port=Config.RABBITMQ_PORT,
+                            vhost=Config.RABBITMQ_VHOST, exchange=Config.RABBITMQ_EXCHANGE,
+                            user=Config.RABBITMQ_USER, password=Config.RABBITMQ_PASSWORD,
+                            queue_name=Config.RABBITMQ_SAMPLE_INBOUND_QUEUE)

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -71,7 +71,7 @@ def check_correct_uac_updated_message_is_emitted(context):
 
 
 @step('a UAC updated event is emitted linking the new UAC and QID to the individual case')
-def check_correct_uac_updated_message_is_emitted(context):
+def check_correct_individual_uac_updated_message_is_emitted(context):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE_TEST,
                                     functools.partial(store_all_msgs_in_context, context=context,

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -1,8 +1,10 @@
 import functools
+import uuid
 
 import requests
 from behave import step
 
+from acceptance_tests.utilities.event_helper import check_individual_child_case_is_emitted
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -12,17 +14,36 @@ from config import Config
       'with case type "{case_type}" and country "{country_code}"')
 def request_telephone_capture_qid_uac(context, case_type, country_code):
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
-
-    test_helper.assertEqual(country_code, context.first_case['treatmentCode'][-1],
-                            'Loaded case does not match expected nationality')
-    test_helper.assertEqual(case_type, context.first_case['treatmentCode'].split('_')[0],
-                            'Loaded case does not match expected case type')
-    test_helper.assertEqual('U', context.first_case['address']['addressLevel'],
-                            'Loaded case does does not have unit address level')
+    _check_case_type_country_address_level(context.first_case, case_type, country_code)
     response = requests.get(f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid")
     test_helper.assertEqual(response.status_code, 200)
 
     context.telephone_capture_qid_uac = response.json()
+
+
+@step('there is a request for individual telephone capture for a unit case '
+      'with case type "{case_type}" and country "{country_code}"')
+def request_individual_telephone_capture_qid_uac(context, case_type, country_code):
+    context.first_case = context.case_created_events[0]['payload']['collectionCase']
+    context.telephone_capture_parent_case_id = context.first_case['id']
+    context.individual_case_id = str(uuid.uuid4())
+    _check_case_type_country_address_level(context.first_case, case_type, country_code)
+    response = requests.get(
+        f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid"
+        f"?individual=true"
+        f"&individualCaseId={context.individual_case_id}")
+    test_helper.assertEqual(response.status_code, 200)
+
+    context.telephone_capture_qid_uac = response.json()
+
+
+def _check_case_type_country_address_level(case, case_type, country_code, address_level='U'):
+    test_helper.assertEqual(country_code, case['treatmentCode'][-1],
+                            'Loaded case does not match expected nationality')
+    test_helper.assertEqual(case_type, case['treatmentCode'].split('_')[0],
+                            'Loaded case does not match expected case type')
+    test_helper.assertEqual(address_level, case['address']['addressLevel'],
+                            'Loaded case does does not have unit address level')
 
 
 @step('a UAC and QID with questionnaire type "{questionnaire_type}" type are generated and returned')
@@ -47,3 +68,27 @@ def check_correct_uac_updated_message_is_emitted(context):
     test_helper.assertEqual(uac_updated_payload['questionnaireId'],
                             context.telephone_capture_qid_uac['questionnaireId'],
                             'UAC updated event QID does not match what the API returned')
+
+
+@step('a UAC updated event is emitted linking the new UAC and QID to the individual case')
+def check_correct_uac_updated_message_is_emitted(context):
+    context.messages_received = []
+    start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE_TEST,
+                                    functools.partial(store_all_msgs_in_context, context=context,
+                                                      expected_msg_count=1,
+                                                      type_filter='UAC_UPDATED'))
+
+    uac_updated_payload = context.messages_received[0]['payload']['uac']
+    test_helper.assertEqual(uac_updated_payload['caseId'], context.individual_case_id,
+                            'UAC updated event case ID does not match the case it was requested for')
+    test_helper.assertEqual(uac_updated_payload['uac'], context.telephone_capture_qid_uac['uac'],
+                            'UAC updated event UAC does not match what the API returned')
+    test_helper.assertEqual(uac_updated_payload['questionnaireId'],
+                            context.telephone_capture_qid_uac['questionnaireId'],
+                            'UAC updated event QID does not match what the API returned')
+
+
+@step('a new individual child case for telephone capture is emitted to RH and Action Scheduler')
+def telephone_capture_child_case_is_emitted(context):
+    check_individual_child_case_is_emitted(context, context.telephone_capture_parent_case_id,
+                                           context.individual_case_id)

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -32,7 +32,7 @@ def request_individual_telephone_capture_qid_uac(context, case_type, country_cod
         f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid"
         f"?individual=true"
         f"&individualCaseId={context.individual_case_id}")
-    test_helper.assertEqual(response.status_code, 200)
+    response.raise_for_status()
 
     context.telephone_capture_qid_uac = response.json()
 

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -17,3 +17,16 @@ Feature: Telephone capture
       | sample_1_english_CE_unit.csv | CE        | E            | 21                 |
       | sample_1_welsh_CE_unit.csv   | CE        | W            | 22                 |
       | sample_1_ni_CE_unit.csv      | CE        | N            | 24                 |
+
+  Scenario Outline: Individual telephone capture request creates new individual case and correct type QID UAC pair and links them
+    Given sample file "<sample file>" is loaded successfully
+    When there is a request for individual telephone capture for a unit case with case type "<case type>" and country "<country code>"
+    Then a UAC and QID with questionnaire type "<questionnaire type>" type are generated and returned
+    And a new individual child case for telephone capture is emitted to RH and Action Scheduler
+    And a UAC updated event is emitted linking the new UAC and QID to the individual case
+
+    Examples:
+      | sample file               | case type | country code | questionnaire type |
+      | sample_1_english_unit.csv | HH        | E            | 21                 |
+      | sample_1_welsh_unit.csv   | HH        | W            | 22                 |
+      | sample_1_ni_unit.csv      | HH        | N            | 24                 |

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -1,0 +1,116 @@
+import functools
+
+import requests
+
+from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context
+from acceptance_tests.utilities.test_case_helper import test_helper
+from config import Config
+
+get_cases_url = f'{Config.CASEAPI_SERVICE}/cases/'
+
+
+def check_individual_child_case_is_emitted(context, parent_case_id, individual_case_id):
+    context.messages_received = []
+
+    start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_CASE_QUEUE_TEST,
+                                    functools.partial(store_all_msgs_in_context, context=context,
+                                                      expected_msg_count=1,
+                                                      type_filter='CASE_CREATED'))
+    test_helper.assertEqual(len(context.messages_received), 1)
+    child_case_arid = context.messages_received[0]['payload']['collectionCase']['address']['estabArid']
+    parent_case_arid = _get_parent_case_estab_arid(parent_case_id)
+
+    test_helper.assertEqual(child_case_arid, parent_case_arid, "Parent and child ARIDs must match to link cases")
+    context.case_created_events = context.messages_received.copy()
+    test_helper.assertEqual(context.case_created_events[0]['payload']['collectionCase']['id'],
+                            individual_case_id)
+
+
+def _get_parent_case_estab_arid(parent_case_id):
+    response = requests.get(f'{get_cases_url}{parent_case_id}')
+    return response.json()['estabArid']
+
+
+def get_qid_and_uac_from_emitted_child_uac(context):
+    context.messages_received = []
+    start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE_TEST,
+                                    functools.partial(
+                                        store_all_msgs_in_context, context=context,
+                                        expected_msg_count=1,
+                                        type_filter='UAC_UPDATED'))
+
+    return context.messages_received[0]['payload']['uac']['uac'], context.messages_received[0]['payload']['uac'][
+        'questionnaireId']
+
+
+def _sample_matches_rh_message(sample_unit, rh_message):
+    return (sample_unit['attributes']['ADDRESS_LINE1'] ==
+            rh_message['payload']['collectionCase']['address']['addressLine1']
+            and sample_unit['attributes']['ADDRESS_LINE2'] ==
+            rh_message['payload']['collectionCase']['address']['addressLine2']
+            and sample_unit['attributes']['REGION'][0] == rh_message['payload']['collectionCase']['address']['region'])
+
+
+def _validate_case(parsed_body):
+    test_helper.assertEqual('CENSUS', parsed_body['payload']['collectionCase']['survey'])
+    test_helper.assertEqual('ACTIONABLE', parsed_body['payload']['collectionCase']['state'])
+    test_helper.assertEqual(8, len(parsed_body['payload']['collectionCase']['caseRef']))
+
+
+def get_cases_and_uac_event_messages(context):
+    get_and_check_case_created_messages(context)
+    get_and_check_uac_updated_messages(context)
+
+
+def get_and_check_case_created_messages(context):
+    context.messages_received = []
+    start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_CASE_QUEUE_TEST,
+                                    functools.partial(store_all_msgs_in_context, context=context,
+                                                      expected_msg_count=len(context.sample_units),
+                                                      type_filter='CASE_CREATED'))
+    context.case_created_events = context.messages_received.copy()
+    _test_cases_correct(context)
+    context.messages_received = []
+
+    context.welsh_cases = [case['payload']['collectionCase'] for case in context.case_created_events
+                           if case['payload']['collectionCase']['treatmentCode'].startswith('HH_Q')
+                           and case['payload']['collectionCase']['treatmentCode'].endswith('W')]
+
+
+def get_and_check_uac_updated_messages(context):
+    start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE_TEST,
+                                    functools.partial(store_all_msgs_in_context, context=context,
+                                                      expected_msg_count=get_expected_uac_count(context),
+                                                      type_filter='UAC_UPDATED'))
+    context.uac_created_events = context.messages_received.copy()
+    _test_uacs_updated_correct(context)
+    context.messages_received = []
+
+
+def _test_uacs_updated_correct(context):
+    case_ids = set(case['payload']['collectionCase']['id'] for case in context.case_created_events)
+    test_helper.assertSetEqual(set(uac['payload']['uac']['caseId'] for uac in context.uac_created_events), case_ids)
+    welsh_uac_count = len(tuple(uac_updated_event for uac_updated_event in context.uac_created_events if
+                                uac_updated_event['payload']['uac']['questionnaireId'].startswith('03')))
+    non_welsh_uac_count = len(context.uac_created_events) - welsh_uac_count
+    test_helper.assertEqual(non_welsh_uac_count, len(context.case_created_events))
+
+    test_helper.assertEqual(welsh_uac_count, len(context.welsh_cases))
+
+
+def _test_cases_correct(context):
+    context.expected_sample_units = context.sample_units.copy()
+
+    for msg in context.case_created_events:
+        _validate_case(msg)
+
+        for index, sample_unit in enumerate(context.expected_sample_units):
+            if _sample_matches_rh_message(sample_unit, msg):
+                del context.expected_sample_units[index]
+                break
+        else:
+            test_helper.fail('Could not find sample unit')
+
+
+def get_expected_uac_count(context):
+    return len(context.welsh_cases) + len(context.case_created_events)


### PR DESCRIPTION
# Motivation and Context
Respondents should be able to request individual telephone capture which spawns a new HI case and telephone capture UAC/QID pair.

# What has changed
* Add scenarios for household individual telephone capture request 
* Factor reusable event code into event_helper utility

# How to test?
Build and run linked feature branches, run these tests

# Links
https://trello.com/c/UJpW7I1J/484-rmc-335-telephone-capture-hi-13
https://github.com/ONSdigital/census-rm-action-scheduler/pull/61
https://github.com/ONSdigital/census-rm-case-api/pull/47
https://github.com/ONSdigital/census-rm-case-processor/pull/95