### PR TITLE
check telephone requests result in fulfilment being logged

### DIFF
--- a/acceptance_tests/features/steps/fulfilment_request.py
+++ b/acceptance_tests/features/steps/fulfilment_request.py
@@ -155,7 +155,7 @@ def create_individual_print_fulfilment_message(context, fulfilment_code):
 
 @step("a fulfilment request event is logged")
 def check_case_events_logged(context):
-    response = requests.get(f"{get_cases_url}{context.first_case['id']}", params={'caseEvents': True})
+    response = requests.get(f"{get_cases_url}{context.fulfilment_requested_case_id}", params={'caseEvents': True})
     response_json = response.json()
     for case_event in response_json['caseEvents']:
         if case_event['description'] == 'Fulfilment Request Received':

--- a/acceptance_tests/features/steps/fulfilment_request.py
+++ b/acceptance_tests/features/steps/fulfilment_request.py
@@ -155,7 +155,7 @@ def create_individual_print_fulfilment_message(context, fulfilment_code):
 
 @step("a fulfilment request event is logged")
 def check_case_events_logged(context):
-    response = requests.get(f'{get_cases_url}{context.fulfilment_requested_case_id}', params={'caseEvents': True})
+    response = requests.get(f"{get_cases_url}{context.first_case['id']}", params={'caseEvents': True})
     response_json = response.json()
     for case_event in response_json['caseEvents']:
         if case_event['description'] == 'Fulfilment Request Received':

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -14,6 +14,7 @@ from config import Config
       'with case type "{case_type}" and country "{country_code}"')
 def request_telephone_capture_qid_uac(context, address_level, case_type, country_code):
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
+    context.fulfilment_requested_case_id = context.case_created_events[0]['payload']['collectionCase']['id']
     _check_case_type_country_address_level(context.first_case, case_type, country_code, address_level=address_level)
     response = requests.get(f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid")
     test_helper.assertEqual(response.status_code, 200)

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -8,6 +8,7 @@ Feature: Telephone capture
     When there is a request for telephone capture for an address level "<address level>" case with case type "<case type>" and country "<country code>"
     Then a UAC and QID with questionnaire type "<questionnaire type>" type are generated and returned
     And a UAC updated event is emitted linking the new UAC and QID to the requested case
+    And a fulfilment request event is logged
 
     Examples:
       | sample file                    | address level | case type | country code | questionnaire type |
@@ -21,7 +22,6 @@ Feature: Telephone capture
       | sample_1_welsh_SPG_unit.csv    | U             | SPG       | W            | 02                 |
       | sample_1_english_SPG_estab.csv | E             | SPG       | E            | 01                 |
       | sample_1_welsh_SPG_estab.csv   | E             | SPG       | W            | 02                 |
-    And a fulfilment request event is logged
 
   Scenario Outline: Individual telephone capture request creates new individual case and correct type QID UAC pair and links them
     Given sample file "<sample file>" is loaded successfully

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -11,7 +11,7 @@ Feature: Telephone capture
 
     Examples:
       | sample file                    | address level | case type | country code | questionnaire type |
-      | sample_1_english_HH_unit.csv    | U             | HH        | E            | 01                 |
+      | sample_1_english_HH_unit.csv   | U             | HH        | E            | 01                 |
       | sample_1_welsh_HH_unit.csv     | U             | HH        | W            | 02                 |
       | sample_1_ni_HH_unit.csv        | U             | HH        | N            | 04                 |
       | sample_1_english_CE_unit.csv   | U             | CE        | E            | 21                 |
@@ -21,6 +21,7 @@ Feature: Telephone capture
       | sample_1_welsh_SPG_unit.csv    | U             | SPG       | W            | 02                 |
       | sample_1_english_SPG_estab.csv | E             | SPG       | E            | 01                 |
       | sample_1_welsh_SPG_estab.csv   | E             | SPG       | W            | 02                 |
+    And a fulfilment request event is logged
 
   Scenario Outline: Individual telephone capture request creates new individual case and correct type QID UAC pair and links them
     Given sample file "<sample file>" is loaded successfully


### PR DESCRIPTION
# Motivation and Context
Log fulfilment against telephone capture

# What has changed
Now checks that a fulfilment is logged against the case when a telephone capture is requested

# How to test?
Run with related PRs for case-api and actionscheduler

# Links
https://trello.com/c/fRwTHZam/483-rmc-335-log-telephone-capture-request-5
# Screenshots (if appropriate):