### PR TITLE
Fix intermittent test failure with QID Batch Runner

### DIFF
--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -69,6 +69,7 @@ run:
       kubectl delete deploy qid-batch-runner --force --now || true
       kubectl apply -f ${BATCH_RUNNER_CONFIG}
       kubectl rollout status deploy qid-batch-runner --watch=true
+      sleep 30s
       kubectl exec -it $(kubectl get pods --selector=app=qid-batch-runner -o jsonpath='{.items[*].metadata.name}') \
       -- /bin/bash /app/run_acceptance_tests.sh
       kubectl delete deploy qid-batch-runner --force --now

--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -69,7 +69,7 @@ run:
       kubectl delete deploy qid-batch-runner --force --now || true
       kubectl apply -f ${BATCH_RUNNER_CONFIG}
       kubectl rollout status deploy qid-batch-runner --watch=true
-      sleep 30s
+      sleep 60s
       kubectl exec -it $(kubectl get pods --selector=app=qid-batch-runner -o jsonpath='{.items[*].metadata.name}') \
       -- /bin/bash /app/run_acceptance_tests.sh
       kubectl delete deploy qid-batch-runner --force --now


### PR DESCRIPTION
# Motivation and Context
The acceptance tests fail intermittently when the QID batch runner tests are starting.

# What has changed
Added a delay before getting the pod ID of the QID batch runner, so that we don't get the pod name of the old pod which is being deleted as well as the new one.

# How to test?
Run this: `kubectl delete deploy qid-batch-runner --force --now && kubectl apply -f qid-batch-runner.yml && kubectl rollout status deploy qid-batch-runner --watch=true && sleep 60s && kubectl get pods --selector=app=qid-batch-runner -o 'jsonpath={.items[*].metadata.name}'`

# Links
Trello: https://trello.com/c/BHoWe9B6