### PR TITLE
RMC-221 CCS case look up by postcode

### DIFF
--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -5,6 +5,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     Then the CCS Property Listed case is created with case_type "HH"
     And the correct ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case
+    And the case API returns the new CCS case by postcode search
 
   Scenario: Log event when a CCS Property Listed event is received with a qid
     When an unaddressed message of questionnaire type 71 is sent
@@ -12,6 +13,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     When a CCS Property Listed event is sent with a qid
     And the CCS Property Listed case is created with case_type "HH"
     And no ActionInstruction is sent to FWMT
+    And the case API returns the new CCS case by postcode search
 
   Scenario: CCS Listed with refusal
     When a CCS Property Listed event is sent with refusal
@@ -19,6 +21,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     And the CCS case listed event is logged
     And no ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case
+    And the case API returns the new CCS case by postcode search
 
   Scenario: CCS Listed with Address invalid
     When a CCS Property Listed event is sent with an address invalid event and addressType "NR"
@@ -26,3 +29,4 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     And the CCS case listed event is logged
     And no ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case
+    And the case API returns the new CCS case by postcode search

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -103,6 +103,7 @@ def get_ccs_case_by_postcode(context):
     test_helper.assertEqual(context.ccs_case['postcode'], matched_case['postcode'])
     test_helper.assertEqual(context.ccs_case['caseRef'], matched_case['caseRef'])
 
+
 @step('it contains the correct fields for a CENSUS case')
 def check_census_case_fields(context):
     test_helper.assertTrue(context.case_details['caseRef'])

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -81,11 +81,27 @@ def find_case_by_case_ref(context):
 def get_ccs_qid_for_case_id(context):
     response = requests.get(f'{case_api_url}ccs/{context.ccs_case["id"]}/qid')
     test_helper.assertEqual(response.status_code, 200, 'CCS QID API call failed')
-    response_json = json.loads(response.text)
+    response_json = response.json()
     test_helper.assertEqual(response_json['questionnaireId'][0:3],
                             '712', 'CCS QID has incorrect questionnaire type or tranche ID')
     test_helper.assertTrue(response_json['active'])
 
+
+@step('the case API returns the new CCS case by postcode search')
+def get_ccs_case_by_postcode(context):
+    response = requests.get(f'{case_api_url}ccs/postcode/{context.ccs_case["postcode"]}')
+    response.raise_for_status()
+    found_cases = response.json()
+
+    for case in found_cases:
+        if case['id'] == context.ccs_case['id']:
+            matched_case = case
+            break
+    else:
+        test_helper.fail('Failed to find the new CCS case by postcode search')
+
+    test_helper.assertEqual(context.ccs_case['postcode'], matched_case['postcode'])
+    test_helper.assertEqual(context.ccs_case['caseRef'], matched_case['caseRef'])
 
 @step('it contains the correct fields for a CENSUS case')
 def check_census_case_fields(context):

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -11,6 +11,7 @@ from acceptance_tests.features.steps.unaddressed import get_case_id_by_questionn
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context, \
     check_no_msgs_sent_to_queue
+from acceptance_tests.utilities.string_utilities import create_random_postcode
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
@@ -80,7 +81,7 @@ def _create_ccs_property_listed_event(context, address_type="HH"):
                     "addressLine2": "Upper upperingham",
                     "addressLine3": "Newport",
                     "townName": "upton",
-                    "postcode": "UP103UP",
+                    "postcode": create_random_postcode(),
                     "latitude": "50.863849",
                     "longitude": "-1.229710",
                     "fieldcoordinatorId": "XXXXXXXXXX",

--- a/acceptance_tests/utilities/string_utilities.py
+++ b/acceptance_tests/utilities/string_utilities.py
@@ -1,7 +1,15 @@
 import string
-from random import choice, randint
+from random import choice, randint, random
 
 
-def create_random_string(min_len, max_len):
+def random_string_upper_or_digits(min_len, max_len):
     random_chars = string.ascii_uppercase + string.digits
     return "".join(choice(random_chars) for _ in range(randint(min_len, max_len)))
+
+
+def create_random_postcode():
+    return (f'{random_string_upper_or_digits(3, 4)}'
+            f'{" " if random() > 0.5 else ""}'
+            f'{choice(string.digits)}'
+            f'{choice(string.ascii_uppercase)}'
+            f'{choice(string.ascii_uppercase)}')


### PR DESCRIPTION
# Motivation and Context
Contact centre needs to be able to search for CCS cases by postcode.

# What has changed
* Add look up by postcode step to CCS scenarios

# How to test?
Build and run RM with the case API on it's feature branch https://github.com/ONSdigital/census-rm-case-api/pull/52, run these tests.

# Links
https://github.com/ONSdigital/census-rm-case-api/pull/52
https://trello.com/c/RxoE4p0V/522-rmc-221-provide-ccs-case-look-up-by-post-code-8