### PR TITLE
Remove case state

### DIFF
--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -110,7 +110,6 @@ def check_census_case_fields(context):
     test_helper.assertTrue(context.case_details['lsoa'])
     test_helper.assertTrue(context.case_details['msoa'])
     test_helper.assertTrue(context.case_details['lad'])
-    test_helper.assertTrue(context.case_details['state'])
     test_helper.assertTrue(context.case_details['id'])
     test_helper.assertTrue(context.case_details['caseType'])
     test_helper.assertEqual(context.case_details['surveyType'], "CENSUS")
@@ -140,7 +139,6 @@ def check_ccs_case_fields(context):
     test_helper.assertFalse(context.ccs_case['lsoa'])
     test_helper.assertFalse(context.ccs_case['msoa'])
     test_helper.assertFalse(context.ccs_case['lad'])
-    test_helper.assertTrue(context.ccs_case['state'])
     test_helper.assertTrue(context.ccs_case['id'])
     test_helper.assertTrue(context.ccs_case['caseType'])
 

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -53,7 +53,6 @@ def _sample_matches_rh_message(sample_unit, rh_message):
 
 def _validate_case(parsed_body):
     test_helper.assertEqual('CENSUS', parsed_body['payload']['collectionCase']['survey'])
-    test_helper.assertEqual('ACTIONABLE', parsed_body['payload']['collectionCase']['state'])
     test_helper.assertEqual(8, len(parsed_body['payload']['collectionCase']['caseRef']))
 
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can now safely remove the redundant case `state` column from our schemas

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed test lines which check against the now redundant `state` case attribute

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the ATs

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/dBJe87ZS/481-get-rid-of-casestate-from-case-table-8

https://github.com/ONSdigital/census-rm-case-processor/pull/101
https://github.com/ONSdigital/census-rm-case-api/pull/53
https://github.com/ONSdigital/census-rm-action-scheduler/pull/64
https://github.com/ONSdigital/census-rm-action-worker/pull/9
https://github.com/ONSdigital/census-rm-ddl/pull/32