### PR TITLE
Action rule in future remove

### DIFF
--- a/acceptance_tests/features/field_reminder.feature
+++ b/acceptance_tests/features/field_reminder.feature
@@ -2,17 +2,17 @@ Feature: Reminder messages are emitted to Field Work Management Tool
 
   Scenario: Tranche 2 household case details to be sent to the Field Work Management Tool
     Given sample file "sample_for_print_stories.csv" is loaded successfully
-    And an action rule of type "FIELD" is set 5 seconds in the future
+    And set action rule of type "FIELD" when the case loading queues are drained
     When the action instruction messages are emitted to FWMT where the case has a "treatmentCode" of "HH_QF2R1E"
     Then the events logged against the tranche 2 fieldwork cases are [FIELD_CASE_SELECTED,SAMPLE_LOADED]
 
 
   Scenario: send community estab cases to field
     Given sample file "sample_for_ce_stories.csv" is loaded successfully
-    When an action rule for address type "CE" is set 5 seconds in the future
+    When an action rule for address type "CE" is set when loading queues are drained
     Then the action instruction is emitted to FWMT where case has a "caseType" of "CE" and CEComplete is "false"
 
   Scenario: send SPG cases to field
     Given sample file "sample_for_spg_stories.csv" is loaded successfully
-    When an action rule for address type "SPG" is set 5 seconds in the future
+    When an action rule for address type "SPG" is set when loading queues are drained
     Then the action instruction is emitted to FWMT where case has a "caseType" of "SPG" and CEComplete is "false"

--- a/acceptance_tests/features/fulfilment_request.feature
+++ b/acceptance_tests/features/fulfilment_request.feature
@@ -83,7 +83,7 @@ Feature: Handle fulfilment request events
 
   Scenario: Generate individual cases and check that no actions rules are triggered for them
     Given sample file "sample_individual_case_spec.csv" is loaded successfully
-    And an action rule of type "FIELD" is set 5 seconds in the future
+    And set action rule of type "FIELD" when the case loading queues are drained
     When a UAC fulfilment request "UACIT1" message for a created case is sent
     Then the action instruction messages for only the HH case are emitted to FWMT where the case has a "treatmentCode" of "HH_QF2R1E"
     And an individual case has been created and only has logged events of [RM_UAC_CREATED]

--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -43,9 +43,9 @@ Feature: Case processor handles receipt message from pubsub service
     Then no ActionInstruction is sent to FWMT
 
   Scenario: Receipted Cases are excluded from print files
-    Given an action rule of type "ICL1E" is set 20 seconds in the future
     And sample file "sample_input_england_census_spec.csv" is loaded successfully
     When the receipt msg for the created case is put on the GCP pubsub
+    And set action rule of type "ICL1E" when case receipted
     Then only unreceipted cases appear in "P_IC_ICL1" print files
     And a case_updated msg is emitted where "receiptReceived" is "True"
     And the events logged for the receipted case are [SAMPLE_LOADED,RESPONSE_RECEIVED]

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -1,8 +1,8 @@
 Feature: Handle refusal message
 
   Scenario: Refusal message results in case excluded from action plan
-    Given an action rule of type "ICL1E" is set 10 seconds in the future
-    And sample file "sample_for_refusals.csv" is loaded successfully
+    Given sample file "sample_for_refusals.csv" is loaded successfully
+    And set action rule of type "ICL1E" when the case loading queues are drained
     When a refusal message for a created case is received
     Then only unrefused cases appear in "P_IC_ICL1" print files
     And the case is marked as refused

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -17,11 +17,8 @@ case_api_url = f'{Config.CASEAPI_SERVICE}/cases/'
 @then("a case can be retrieved from the case API service")
 def get_case_by_id(context):
     case_id = context.case_created_events[0]['payload']['collectionCase']['id']
-
     response = requests.get(f'{case_api_url}{case_id}')
-
     test_helper.assertEqual(response.status_code, 200, 'Case not found')
-
     context.case_details = response.json()
 
 


### PR DESCRIPTION
# Motivation and Context
Action rules in future both inefficient and don't always work

# What has changed
Stops doing that and waits for queues to drain or receipts to be received 

# How to test?
Should work with everything else on master

# Links
https://trello.com/c/7kaU77Fg/575-acceptance-test-action-rule-timings-fix

# Screenshots (if appropriate):