### PR TITLE
Add wait to field action rule create

### DIFF
--- a/acceptance_tests/features/field_reminder.feature
+++ b/acceptance_tests/features/field_reminder.feature
@@ -8,11 +8,11 @@ Feature: Reminder messages are emitted to Field Work Management Tool
     
   Scenario: send community estab cases to field
     Given sample file "sample_for_ce_stories.csv" is loaded successfully
-    When an action rule for address type "CE" is set when loading queues are drained
+    When a FIELD action rule for address type "CE" is set when loading queues are drained
     Then the action instruction is emitted to FWMT where case has a "caseType" of "CE" and CEComplete is "false"
 
   Scenario: send SPG cases to field
     Given sample file "sample_for_spg_stories.csv" is loaded successfully
-    When an action rule for address type "SPG" is set when loading queues are drained
+    When a FIELD action rule for address type "SPG" is set when loading queues are drained
     Then the action instruction is emitted to FWMT where case has a "caseType" of "SPG" and CEComplete is "false"
 


### PR DESCRIPTION
# Motivation and Context
This step has been failing as the wait for queue to be drained is not reliably waiting for every case to reach action before kicking off the action rule. As a stop gap I've added a sleep as has been done in a similar step. 

# What has changed
* Clarify some step and function names
* Add sleep to field action rule setup

# How to test?
Run the tests. The real test will be how reliably it passes in CI.

# Links
https://trello.com/c/NEFQR3Ie/597-fix-flakey-send-cases-to-field-acceptance-test-step