### PR TITLE
Fix issue with failure logging in refusal feature

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -55,7 +55,7 @@ def after_tag(_, tag):
 
 
 def _clear_queues_for_bad_messages_and_reset_exception_manager():
-    for _ in range(0, 4):
+    for _ in range(4):
         purge_queues(*Config.RABBITMQ_QUEUES, 'delayedRedeliveryQueue', 'RM.Field')
         time.sleep(1)
     time.sleep(5)

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -55,7 +55,7 @@ def after_tag(_, tag):
 
 
 def _clear_queues_for_bad_messages_and_reset_exception_manager():
-    for i in range(0, 4):
+    for _ in range(0, 4):
         purge_queues(*Config.RABBITMQ_QUEUES, 'delayedRedeliveryQueue', 'RM.Field')
         time.sleep(1)
     time.sleep(5)

--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -16,7 +16,8 @@ caseapi_url = f'{Config.CASEAPI_SERVICE}/cases/'
 
 @step("a refusal message for a created case is received")
 def create_refusal(context):
-    context.refused_case_id = context.uac_created_events[0]['payload']['uac']['caseId']
+    context.first_case = context.case_created_events[0]['payload']['collectionCase']
+    context.refused_case_id = context.first_case['id']
 
     message = json.dumps(
         {


### PR DESCRIPTION
# Motivation and Context
The refusal feature was falling over if it failed in a particular place because it never sets the `first_case` context item which some of the generalised steps expect.

# What has changed
* Set first case context item in refusal setup
* Small style tweak

# How to test?
Run the refusal feature

# Links
https://trello.com/c/4wpsQDGU/631-fix-flakey-acceptance-test-sample-load