### PR TITLE
Improve case created event checking

### DIFF
--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -116,9 +116,9 @@ def _test_cases_correct(context):
                 context.expected_sample_units.pop(index)
                 break
         else:
-            logger.error('Failed to find all expected sample units',
+            logger.error('To match case created event to any of the expected sample units',
                          unmatched_sample_units=context.expected_sample_units,
-                         case_created_events=context.case_created_events)
+                         case_created_event=event)
             test_helper.fail('Could not find correct case updated messages for all loaded sample units')
 
 

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -46,12 +46,15 @@ def get_qid_and_uac_from_emitted_child_uac(context):
         'questionnaireId']
 
 
-def _sample_matches_rh_message(sample_unit, rh_message):
-    return (sample_unit['attributes']['ADDRESS_LINE1'] ==
-            rh_message['payload']['collectionCase']['address']['addressLine1']
-            and sample_unit['attributes']['ADDRESS_LINE2'] ==
-            rh_message['payload']['collectionCase']['address']['addressLine2']
-            and sample_unit['attributes']['REGION'][0] == rh_message['payload']['collectionCase']['address']['region'])
+def _sample_unit_matches_case_event(sample_unit, case_created_event):
+    return (sample_unit['attributes']['ARID'] ==
+            case_created_event['payload']['collectionCase']['address']['arid']
+            and sample_unit['attributes']['ESTAB_ARID'] ==
+            case_created_event['payload']['collectionCase']['address']['estabArid']
+            and sample_unit['attributes']['UPRN'] ==
+            case_created_event['payload']['collectionCase']['address']['uprn']
+            and sample_unit['attributes']['ADDRESS_LEVEL'] ==
+            case_created_event['payload']['collectionCase']['address']['addressLevel'])
 
 
 def _validate_case(parsed_body):
@@ -102,17 +105,19 @@ def _test_uacs_updated_correct(context):
 
 def _test_cases_correct(context):
     context.expected_sample_units = context.sample_units.copy()
+    test_helper.assertEqual(len(context.expected_sample_units), len(context.case_created_events),
+                            'Number of cases loaded and case created events do not match')
 
-    for msg in context.case_created_events:
-        _validate_case(msg)
+    for event in context.case_created_events:
+        _validate_case(event)
 
         for index, sample_unit in enumerate(context.expected_sample_units):
-            if _sample_matches_rh_message(sample_unit, msg):
-                del context.expected_sample_units[index]
+            if _sample_unit_matches_case_event(sample_unit, event):
+                context.expected_sample_units.pop(index)
                 break
         else:
             logger.error('Failed to find all expected sample units',
-                         expected_sample_units=context.expected_sample_units,
+                         unmatched_sample_units=context.expected_sample_units,
                          case_created_events=context.case_created_events)
             test_helper.fail('Could not find correct case updated messages for all loaded sample units')
 


### PR DESCRIPTION
# Motivation and Context
The sample load step is sometimes failing to match up the case created events with expected sample units, this is an attempt to improve that logic at bit and at least make failures clearer.

# What has changed
* Improve case created event checking
* Match units to events based on arids, uprn and address level instead of address lines

# How to test?
Run the AT's

# Links
https://trello.com/c/4wpsQDGU/631-fix-flakey-acceptance-test-sample-load