### PR TITLE
Check that we send derived formType on UACUpdated msgs

### DIFF
--- a/acceptance_tests/features/ad_hoc_uac_qid.feature
+++ b/acceptance_tests/features/ad_hoc_uac_qid.feature
@@ -10,5 +10,5 @@ Feature: A UAC/QID pair can be requested for a case
       | 01                 |
       | 02                 |
       | 04                 |
-      | 37                 |
-      | 99                 |
+      | 34                 |
+      | 83                 |

--- a/acceptance_tests/features/steps/ad_hoc_uac_qid.py
+++ b/acceptance_tests/features/steps/ad_hoc_uac_qid.py
@@ -9,6 +9,15 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 caseapi_uacqid_pair_url = f'{Config.CASEAPI_SERVICE}/uacqid/create'
+questionnaire_type_to_form_type_map = {"01": "H", "02": "H", "03": "H", "04": "H",
+                                       "11": None, "12": None, "13": None, "14": None,
+                                       "21": "I", "22": "I", "23": "I", "24": "I",
+                                       "31": "C", "32": "C", "33": "C", "34": "C",
+                                       "41": None, "42": None, "43": None, "44": None,
+                                       "51": "H", "52": "H", "53": "H", "54": "H",
+                                       "61": None, "62": None, "63": None, "64": None,
+                                       "71": "H", "72": "H", "73": "H", "74": "H",
+                                       "81": "C", "82": "C", "83": "C", "84": "C"}
 
 
 @when('a UAC/QID pair is requested with questionnaire type "{questionnaire_type}"')
@@ -44,6 +53,16 @@ def listen_for_ad_hoc_uac_updated_message(context, questionnaire_type):
                            'Fulfilment request UAC updated event found with wrong questionnaire type')
     context.requested_uac = uac_updated_event['payload']['uac']['uac']
     context.requested_qid = uac_updated_event['payload']['uac']['questionnaireId']
+
+    # Check that the moon is on a stick for anybody who can't implement project-wide business logic
+    actual_questionnaire_type = uac_updated_event['payload']['uac']['questionnaireId'][:2]
+    expected_form_type = questionnaire_type_to_form_type_map[actual_questionnaire_type]
+
+    if expected_form_type:
+        test_helper.assertEqual(uac_updated_event['payload']['uac']['formType'], expected_form_type,
+                                "The moon is NOT on a stick to our satisfaction")
+    else:
+        test_helper.assertIsNone(uac_updated_event['payload']['uac'].get('formType'))
 
 
 @step('two UAC updated messages with "{questionnaire_type}" questionnaire type are emitted')

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -54,6 +54,7 @@ def uac_updated_msg_emitted(context):
     uac = context.messages_received[0]['payload']['uac']
     test_helper.assertEqual(uac['caseId'], context.first_case['id'])
     test_helper.assertFalse(uac['active'])
+    test_helper.assertIsNotNone(uac['formType'])
 
 
 @step('an ActionCancelled event is sent to field work management with addressType "{address_type}"')

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -54,6 +54,8 @@ def uac_updated_msg_emitted(context):
     uac = context.messages_received[0]['payload']['uac']
     test_helper.assertEqual(uac['caseId'], context.first_case['id'])
     test_helper.assertFalse(uac['active'])
+
+    # Check that the moon is on a stick
     test_helper.assertIsNotNone(uac['formType'])
 
 

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -55,9 +55,6 @@ def uac_updated_msg_emitted(context):
     test_helper.assertEqual(uac['caseId'], context.first_case['id'])
     test_helper.assertFalse(uac['active'])
 
-    # Check that the moon is on a stick
-    test_helper.assertIsNotNone(uac['formType'])
-
 
 @step('an ActionCancelled event is sent to field work management with addressType "{address_type}"')
 @step('an ActionCancelled Invalid Address event is sent to field work management with addressType "{address_type}"')


### PR DESCRIPTION
# Motivation and Context
RH wanted some data which they could have derived, so we are begrudgingly providing it.

# What has changed
Check the formType is on the message.

# How to test?
Run the ATs.

# Links
Trello: https://trello.com/c/nGDQ3eJF