### PR TITLE
Check for survey name on field close messages

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -4,7 +4,7 @@ Feature: Address updates
     Given sample file "<sample file>" is loaded successfully
     When an invalid address message is sent from "CC"
     Then a case_updated msg is emitted where "addressInvalid" is "True"
-    And an ActionCancelled Invalid Address event is sent to field work management with addressType "<address type>"
+    And a CLOSE action instruction is sent to field work management with addressType "<address type>"
     And the case event log records invalid address
 
     Examples:
@@ -18,7 +18,7 @@ Feature: Address updates
     Given sample file "<sample file>" is loaded successfully
     When an invalid address message is sent from "CC"
     Then a case_updated msg is emitted where "addressInvalid" is "True"
-    And an ActionCancelled Invalid Address event is sent to field work management with addressType "<address type>"
+    And a CLOSE action instruction is sent to field work management with addressType "<address type>"
     And the case event log records invalid address
 
     Examples:

--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -45,7 +45,7 @@ Feature: Case processor handles receipt message from pubsub service
     When the offline receipt msg for the created case is put on the GCP pubsub
     Then a uac_updated msg is emitted with active set to false
     And a case_updated msg is emitted where "receiptReceived" is "True"
-    And an ActionCancelled event is sent to field work management with addressType "HH"
+    And a CLOSE action instruction is sent to field work management with addressType "HH"
     And the events logged for the receipted case are [SAMPLE_LOADED,RESPONSE_RECEIVED]
 
 

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -6,5 +6,5 @@ Feature: Handle refusal message
     And set action rule of type "ICL1E" when case event "REFUSAL_RECEIVED" is logged
     Then only unrefused cases appear in "P_IC_ICL1" print files
     And the case is marked as refused
-    And an action instruction cancel message is emitted to FWMT
+    And a CLOSE action instruction is emitted to FWMT
     And the events logged for the refusal case are [SAMPLE_LOADED,REFUSAL_RECEIVED]

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -55,7 +55,7 @@ def uac_updated_msg_emitted(context):
 
 
 @step('a CLOSE action instruction is sent to field work management with addressType "{address_type}"')
-def action_cancelled_event_sent_to_fwm(context, address_type):
+def action_close_sent_to_fwm(context, address_type):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE, functools.partial(
         _field_work_close_callback, context=context))

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -247,6 +247,7 @@ def check_receipt_to_field_msg(context, action_instruction_type, incremented):
     msg_to_field = context.messages_received[0]
     test_helper.assertEquals(msg_to_field['caseId'], context.receipting_case['id'])
     test_helper.assertEquals(msg_to_field['actionInstruction'], action_instruction_type)
+    test_helper.assertEqual(msg_to_field['surveyName'], context.receipting_case['survey'])
 
 
 @step('the correct events are logged for "{loaded_case_events}" and "{individual_case_events}"')

--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -5,7 +5,7 @@ import requests
 from behave import step
 
 from acceptance_tests.features.steps.event_log import check_if_event_list_is_exact_match
-from acceptance_tests.features.steps.receipt import _field_work_receipt_callback
+from acceptance_tests.features.steps.receipt import _field_work_close_callback
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue
 from acceptance_tests.utilities.test_case_helper import test_helper
@@ -73,10 +73,10 @@ def check_case_events(context):
     test_helper.fail('Did not find "Refusal Received" event')
 
 
-@step('an action instruction cancel message is emitted to FWMT')
+@step('a CLOSE action instruction is emitted to FWMT')
 def refusal_received(context):
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE,
-                                    functools.partial(_field_work_receipt_callback, context=context))
+                                    functools.partial(_field_work_close_callback, context=context))
 
     test_helper.assertEqual(context.fwmt_emitted_case_id, context.refused_case_id)
     test_helper.assertEqual(context.addressType, 'HH')


### PR DESCRIPTION
# Motivation and Context
We were missing `surveyName` on outbound field `CLOSE` messages, tests now check for it.

# What has changed
* Check survey name on field close messages
* Update language to reflect action instruction changes

# How to test?
Build and run with linked fieldwork adapter branch

# Links
https://trello.com/c/nwGrBR4Q/639-tweak-outbound-fwmt-close-msg-to-match-interface
https://github.com/ONSdigital/census-rm-fieldwork-adapter/pull/32