### PR TITLE
Attempt at fixing sample load test in CI pipeline

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -18,7 +18,6 @@ def before_scenario(context, _):
     context.test_start_local_datetime = datetime.now()
     context.collection_exercise_id = str(uuid.uuid4())
     context.action_plan_id = str(uuid.uuid4())
-    context.collection_exercise_id = str(uuid.uuid4())
     purge_queues(Config.RABBITMQ_INBOUND_REFUSAL_QUEUE,
                  Config.RABBITMQ_RH_OUTBOUND_CASE_QUEUE,
                  Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,

--- a/acceptance_tests/features/steps/ad_hoc_uac_qid.py
+++ b/acceptance_tests/features/steps/ad_hoc_uac_qid.py
@@ -4,7 +4,8 @@ import json
 import requests
 from behave import then, when, step
 
-from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context
+from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, \
+    store_all_uac_updated_msgs_by_collection_exercise_id
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
@@ -43,9 +44,10 @@ def generate_uacqid_pair(context):
 def listen_for_ad_hoc_uac_updated_message(context, questionnaire_type):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,
-                                    functools.partial(store_all_msgs_in_context, context=context,
+                                    functools.partial(store_all_uac_updated_msgs_by_collection_exercise_id,
+                                                      context=context,
                                                       expected_msg_count=1,
-                                                      type_filter='UAC_UPDATED'))
+                                                      collection_exercise_id=context.collection_exercise_id))
     uac_updated_event = context.messages_received[0]
     test_helper.assertEqual(uac_updated_event['payload']['uac']['caseId'], context.first_case['id'],
                             'Fulfilment request UAC updated event found with wrong case ID')
@@ -69,9 +71,10 @@ def listen_for_ad_hoc_uac_updated_message(context, questionnaire_type):
 def listen_for_two_ad_hoc_uac_updated_messages(context, questionnaire_type):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,
-                                    functools.partial(store_all_msgs_in_context, context=context,
+                                    functools.partial(store_all_uac_updated_msgs_by_collection_exercise_id,
+                                                      context=context,
                                                       expected_msg_count=2,
-                                                      type_filter='UAC_UPDATED'))
+                                                      collection_exercise_id=context.collection_exercise_id))
     uac_updated_events = context.messages_received
 
     test_helper.assertEqual(len(uac_updated_events), len(context.print_cases),

--- a/acceptance_tests/features/steps/case_events.py
+++ b/acceptance_tests/features/steps/case_events.py
@@ -4,7 +4,8 @@ import functools
 from behave import step
 
 from acceptance_tests.utilities.event_helper import get_and_check_case_created_messages
-from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context
+from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, \
+    store_all_uac_updated_msgs_by_collection_exercise_id
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
@@ -15,9 +16,10 @@ def gather_messages_emitted_with_qids(context, questionnaire_types):
 
     context.expected_uacs_cases = _get_extended_case_created_events_for_uacs(context, questionnaire_types)
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,
-                                    functools.partial(store_all_msgs_in_context, context=context,
+                                    functools.partial(store_all_uac_updated_msgs_by_collection_exercise_id,
+                                                      context=context,
                                                       expected_msg_count=len(context.expected_uacs_cases),
-                                                      type_filter='UAC_UPDATED'))
+                                                      collection_exercise_id=context.collection_exercise_id))
     test_helper.assertEqual(len(context.messages_received), len(context.expected_uacs_cases))
     context.uac_created_events = context.messages_received.copy()
     _test_uacs_correct(context)
@@ -27,9 +29,10 @@ def gather_messages_emitted_with_qids(context, questionnaire_types):
 @step('UAC Updated events emitted for the {number_of_matching_cases:d} cases with matching treatment codes')
 def gather_uac_updated_events(context, number_of_matching_cases):
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,
-                                    functools.partial(store_all_msgs_in_context, context=context,
+                                    functools.partial(store_all_uac_updated_msgs_by_collection_exercise_id,
+                                                      context=context,
                                                       expected_msg_count=number_of_matching_cases,
-                                                      type_filter='UAC_UPDATED'))
+                                                      collection_exercise_id=context.collection_exercise_id))
     test_helper.assertEqual(len(context.messages_received), number_of_matching_cases)
     context.reminder_uac_updated_events = context.messages_received.copy()
     context.reminder_case_ids = {uac['payload']['uac']['caseId'] for uac in context.reminder_uac_updated_events}
@@ -40,9 +43,10 @@ def gather_uac_updated_events(context, number_of_matching_cases):
 def gather_welsh_reminder_uac_events(context, number_of_matching_cases):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,
-                                    functools.partial(store_all_msgs_in_context, context=context,
+                                    functools.partial(store_all_uac_updated_msgs_by_collection_exercise_id,
+                                                      context=context,
                                                       expected_msg_count=number_of_matching_cases * 2,
-                                                      type_filter='UAC_UPDATED'))
+                                                      collection_exercise_id=context.collection_exercise_id))
     test_helper.assertEquals(len(context.messages_received), number_of_matching_cases * 2)
     context.reminder_uac_updated_events = context.messages_received.copy()
     context.reminder_case_ids = {uac['payload']['uac']['caseId'] for uac in context.reminder_uac_updated_events}

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -6,7 +6,8 @@ from behave import step
 
 from acceptance_tests.utilities.event_helper import check_individual_child_case_is_emitted
 from acceptance_tests.utilities.mappings import QUESTIONNAIRE_TYPE_TO_FORM_TYPE
-from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_all_msgs_in_context
+from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, \
+    store_all_uac_updated_msgs_by_collection_exercise_id
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
@@ -79,9 +80,10 @@ def check_telephone_capture_uac_and_qid_type(context, questionnaire_type):
 def check_correct_uac_updated_message_is_emitted(context):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,
-                                    functools.partial(store_all_msgs_in_context, context=context,
+                                    functools.partial(store_all_uac_updated_msgs_by_collection_exercise_id,
+                                                      context=context,
                                                       expected_msg_count=1,
-                                                      type_filter='UAC_UPDATED'))
+                                                      collection_exercise_id=context.collection_exercise_id))
 
     uac_updated_payload = context.messages_received[0]['payload']['uac']
     test_helper.assertEqual(uac_updated_payload['caseId'], context.first_case['id'],
@@ -97,9 +99,10 @@ def check_correct_uac_updated_message_is_emitted(context):
 def check_correct_individual_uac_updated_message_is_emitted(context):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,
-                                    functools.partial(store_all_msgs_in_context, context=context,
+                                    functools.partial(store_all_uac_updated_msgs_by_collection_exercise_id,
+                                                      context=context,
                                                       expected_msg_count=1,
-                                                      type_filter='UAC_UPDATED'))
+                                                      collection_exercise_id=context.collection_exercise_id))
 
     uac_updated_payload = context.messages_received[0]['payload']['uac']
     test_helper.assertEqual(uac_updated_payload['caseId'], context.individual_case_id,

--- a/acceptance_tests/utilities/rabbit_helper.py
+++ b/acceptance_tests/utilities/rabbit_helper.py
@@ -44,6 +44,39 @@ def store_all_msgs_in_context(ch, method, _properties, body, context, expected_m
         ch.stop_consuming()
 
 
+def store_all_case_created_msgs_by_collection_exercise_id(ch, method, _properties, body, context, expected_msg_count,
+                                                          collection_exercise_id):
+    parsed_body = json.loads(body)
+
+    if (parsed_body['event']['type'] == 'CASE_CREATED' and
+            parsed_body['payload']['collectionCase']['collectionExerciseId'] == collection_exercise_id):
+        context.messages_received.append(parsed_body)
+        ch.basic_ack(delivery_tag=method.delivery_tag)
+    else:
+        # take it, ignore it?
+        ch.basic_nack(delivery_tag=method.delivery_tag)
+
+    if len(context.messages_received) == expected_msg_count:
+        ch.stop_consuming()
+
+
+def store_all_uac_updated_msgs_by_collection_exercise_id(ch, method, _properties, body, context, expected_msg_count,
+                                                         collection_exercise_id):
+    parsed_body = json.loads(body)
+
+    if (parsed_body['event']['type'] == 'UAC_UPDATED' and
+            parsed_body['payload']['uac']['collectionExerciseId'] == collection_exercise_id):
+        context.messages_received.append(parsed_body)
+        ch.basic_ack(delivery_tag=method.delivery_tag)
+    else:
+        # take it, ignore it?
+
+        ch.basic_nack(delivery_tag=method.delivery_tag)
+
+    if len(context.messages_received) == expected_msg_count:
+        ch.stop_consuming()
+
+
 def store_first_message_in_context(ch, method, _properties, body, context, type_filter=None):
     parsed_body = json.loads(body)
     if parsed_body['event']['type'] == type_filter or type_filter is None:


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Theres a test in the acceptance tests that fails on sample load. I have modified the message listeners for case_created and uac_created messages to make sure that all messages have the same collection exercise id. Hopefully it should just grab messages related to its own collection exercise.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Message listeners on case_created and uac_updated only ack if the message is the correct collection exercise id.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run acceptance tests in docker and GCP

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/J26KaRJF/659-spike-acceptance-test-intermittently-failing-sample-load-round-2-2-days)
