### PR TITLE
addressType and caseType confusion

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -1,10 +1,10 @@
 Feature: Address updates
 
-  Scenario Outline: Invalid address event for HH, CE and SPG case types for unit level cases
+  Scenario Outline: Invalid address event for HH, CE and SPG address types for unit level cases
     Given sample file "<sample file>" is loaded successfully
     When an invalid address message is sent from "CC"
     Then a case_updated msg is emitted where "addressInvalid" is "True"
-    And a CLOSE action instruction is sent to field work management with addressType "<address type>"
+    And a CLOSE action instruction is sent to field work management with address type "<address type>"
     And the case event log records invalid address
 
     Examples:
@@ -14,11 +14,11 @@ Feature: Address updates
       | sample_for_invalid_address_SPG_U.csv | SPG          |
 
 
-  Scenario Outline: Invalid address event for CE and SPG case types for Estab level cases
+  Scenario Outline: Invalid address event for CE and SPG address types for Estab level cases
     Given sample file "<sample file>" is loaded successfully
     When an invalid address message is sent from "CC"
     Then a case_updated msg is emitted where "addressInvalid" is "True"
-    And a CLOSE action instruction is sent to field work management with addressType "<address type>"
+    And a CLOSE action instruction is sent to field work management with address type "<address type>"
     And the case event log records invalid address
 
     Examples:
@@ -28,9 +28,9 @@ Feature: Address updates
 
     Scenario: Invalid address event for CCS unit level case
     Given a CCS Property Listed event is sent
-    And the CCS Property Listed case is created with case_type "HH"
+    And the CCS Property Listed case is created with address type "HH"
     And the correct ActionInstruction is sent to FWMT
     When an invalid address message for the CCS case is sent from "CC"
     Then a case_updated msg is emitted where "addressInvalid" is "True"
-    And a CLOSE action instruction is sent to field work management with addressType "HH"
+    And a CLOSE action instruction is sent to field work management with address type "HH"
     And the case event log records invalid address

--- a/acceptance_tests/features/case_look_up.feature
+++ b/acceptance_tests/features/case_look_up.feature
@@ -31,5 +31,5 @@ Feature: Case look up for the contact centre
 
   Scenario: Check case-api returns correct fields for a CCS case
     When a CCS Property Listed event is sent
-    Then the CCS Property Listed case is created with case_type "HH"
+    Then the CCS Property Listed case is created with address type "HH"
     And it contains the correct fields for a CCS case

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -2,7 +2,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
 
   Scenario: Log event when a CCS Property Listed event is received with no qid
     When a CCS Property Listed event is sent
-    Then the CCS Property Listed case is created with address_type "HH"
+    Then the CCS Property Listed case is created with address type "HH"
     And the correct ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case
     And the case API returns the new CCS case by postcode search
@@ -11,21 +11,21 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     When an unaddressed message of questionnaire type 71 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     When a CCS Property Listed event is sent with a qid
-    And the CCS Property Listed case is created with address_type "HH"
+    And the CCS Property Listed case is created with address type "HH"
     And no ActionInstruction is sent to FWMT
     And the case API returns the new CCS case by postcode search
 
   Scenario: CCS Listed with refusal
     When a CCS Property Listed event is sent with refusal
-    Then the CCS Property Listed case is created with address_type "HH"
+    Then the CCS Property Listed case is created with address type "HH"
     And the CCS case listed event is logged
     And no ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case
     And the case API returns the new CCS case by postcode search
 
   Scenario: CCS Listed with Address invalid
-    When a CCS Property Listed event is sent with an address invalid event and addressType "NR"
-    Then the CCS Property Listed case is created with address_type "NR"
+    When a CCS Property Listed event is sent with an address invalid event and address type "NR"
+    Then the CCS Property Listed case is created with address type "NR"
     And the CCS case listed event is logged
     And no ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -2,7 +2,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
 
   Scenario: Log event when a CCS Property Listed event is received with no qid
     When a CCS Property Listed event is sent
-    Then the CCS Property Listed case is created with case_type "HH"
+    Then the CCS Property Listed case is created with address_type "HH"
     And the correct ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case
     And the case API returns the new CCS case by postcode search
@@ -11,13 +11,13 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     When an unaddressed message of questionnaire type 71 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     When a CCS Property Listed event is sent with a qid
-    And the CCS Property Listed case is created with case_type "HH"
+    And the CCS Property Listed case is created with address_type "HH"
     And no ActionInstruction is sent to FWMT
     And the case API returns the new CCS case by postcode search
 
   Scenario: CCS Listed with refusal
     When a CCS Property Listed event is sent with refusal
-    Then the CCS Property Listed case is created with case_type "HH"
+    Then the CCS Property Listed case is created with address_type "HH"
     And the CCS case listed event is logged
     And no ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case
@@ -25,7 +25,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
 
   Scenario: CCS Listed with Address invalid
     When a CCS Property Listed event is sent with an address invalid event and addressType "NR"
-    Then the CCS Property Listed case is created with case_type "NR"
+    Then the CCS Property Listed case is created with address_type "NR"
     And the CCS case listed event is logged
     And no ActionInstruction is sent to FWMT
     And the case API returns the CCS QID for the new case

--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -2,26 +2,26 @@ Feature: Case processor handles receipt message from pubsub service
 
   Scenario Outline: Receipted Cases increment ceActualResponses
     Given sample file "<sample file>" is loaded successfully
-    And if required a new qid and case are created for case type "<case type>" address level "<address level>" qid type "<qid type>" and country "<country>"
+    And if required a new qid and case are created for address type "<address type>" address level "<address level>" qid type "<qid type>" and country "<country>"
     When the receipt msg is put on the GCP pubsub
     Then a uac_updated msg is emitted with active set to false for the receipted qid
     And the correct events are logged for loaded case events "[<loaded case events>]" and individual case events "[<individual case events>]"
-    And if the actual response count is incremented "<increment>" or the case is marked receipted "<receipt>" then there should be a case updated message of case type "<case type>"
+    And if the actual response count is incremented "<increment>" or the case is marked receipted "<receipt>" then there should be a case updated message of address type "<address type>"
     And if the field instruction "<instruction>" is not NONE a msg to field is emitted where ceActualResponse is incremented "<increment>"
 
     Examples:
-      | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
-      | HH        | U             | HH       | False     | True    | CLOSE       | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | HH        | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
-      | HI        | U             | Ind      | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | FULFILMENT_REQUESTED,SAMPLE_LOADED                                                      | RESPONSE_RECEIVED,RM_UAC_CREATED |
-      | CE        | E             | Ind      | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | CE        | E             | CE1      | False     | True    | UPDATE      | sample_1_english_CE_estab.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | CE        | U             | Ind      | True      | AR >= E | UPDATE      | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | SPG       | E             | HH       | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | SPG       | E             | Ind      | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | SPG       | U             | HH       | False     | True    | CLOSE       | sample_1_english_SPG_unit.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | SPG       | U             | Ind      | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | SPG       | U             | Cont     | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
+      | address type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
+      | HH           | U             | HH       | False     | True    | CLOSE       | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
+      | HH           | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
+      | HI           | U             | Ind      | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | FULFILMENT_REQUESTED,SAMPLE_LOADED                                                      | RESPONSE_RECEIVED,RM_UAC_CREATED |
+      | CE           | E             | Ind      | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
+      | CE           | E             | CE1      | False     | True    | UPDATE      | sample_1_english_CE_estab.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
+      | CE           | U             | Ind      | True      | AR >= E | UPDATE      | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
+      | SPG          | E             | HH       | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
+      | SPG          | E             | Ind      | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
+      | SPG          | U             | HH       | False     | True    | CLOSE       | sample_1_english_SPG_unit.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
+      | SPG          | U             | Ind      | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
+      | SPG          | U             | Cont     | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
 
 
   Scenario: Receipted Cases are excluded from print files
@@ -35,18 +35,18 @@ Feature: Case processor handles receipt message from pubsub service
     Given an unaddressed message of questionnaire type 63 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     And a CCS Property Listed event is sent with a qid
-    And the CCS Property Listed case is created with case_type "HH"
+    And the CCS Property Listed case is created with address type "HH"
     When the offline receipt msg for a continuation form from the case is received
     Then no ActionInstruction is sent to FWMT
 
   Scenario: eq receipt for CCS case results in UAC updated event sent to RH
     Given a CCS Property Listed event is sent
-    And the CCS Property Listed case is created with case_type "HH"
+    And the CCS Property Listed case is created with address type "HH"
     And the correct ActionInstruction is sent to FWMT
     When the receipt msg for the created CCS case is put on the GCP pubsub
     Then a uac_updated msg is emitted with active set to false
     And a case_updated msg is emitted where "receiptReceived" is "True"
-    And a CLOSE action instruction is sent to field work management with addressType "HH"
+    And a CLOSE action instruction is sent to field work management with address type "HH"
     And the events logged for the receipted case are [CCS_ADDRESS_LISTED,RESPONSE_RECEIVED]
 
   Scenario: PQRS receipt results in UAC updated event sent to RH
@@ -54,7 +54,7 @@ Feature: Case processor handles receipt message from pubsub service
     When the offline receipt msg for the created case is put on the GCP pubsub
     Then a uac_updated msg is emitted with active set to false
     And a case_updated msg is emitted where "receiptReceived" is "True"
-    And a CLOSE action instruction is sent to field work management with addressType "HH"
+    And a CLOSE action instruction is sent to field work management with address type "HH"
     And the events logged for the receipted case are [SAMPLE_LOADED,RESPONSE_RECEIVED]
 
   Scenario: PQRS receipt for continuation questionnaire from fulfilment does not send to Field

--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -2,15 +2,15 @@ Feature: Case processor handles receipt message from pubsub service
 
   Scenario Outline: Receipted Cases increment ceActualResponses
     Given sample file "<sample file>" is loaded successfully
-    And if required a new qid and case are created for address type "<address type>" address level "<address level>" qid type "<qid type>" and country "<country>"
+    And if required a new qid and case are created for case type "<case type>" address level "<address level>" qid type "<qid type>" and country "<country>"
     When the receipt msg is put on the GCP pubsub
     Then a uac_updated msg is emitted with active set to false for the receipted qid
     And the correct events are logged for loaded case events "[<loaded case events>]" and individual case events "[<individual case events>]"
-    And if the actual response count is incremented "<increment>" or the case is marked receipted "<receipt>" then there should be a case updated message of address type "<address type>"
+    And if the actual response count is incremented "<increment>" or the case is marked receipted "<receipt>" then there should be a case updated message of case type "<case type>"
     And if the field instruction "<instruction>" is not NONE a msg to field is emitted where ceActualResponse is incremented "<increment>"
 
     Examples:
-      | address type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
+      | case type    | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
       | HH           | U             | HH       | False     | True    | CLOSE       | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
       | HH           | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
       | HI           | U             | Ind      | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | FULFILMENT_REQUESTED,SAMPLE_LOADED                                                      | RESPONSE_RECEIVED,RM_UAC_CREATED |

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -11,7 +11,7 @@ Feature: Handle refusal message
 
   Scenario: Refusal message results in CCS case excluded from action plan
     Given a CCS Property Listed event is sent
-    And the CCS Property Listed case is created with address_type "HH"
+    And the CCS Property Listed case is created with address type "HH"
     And the correct ActionInstruction is sent to FWMT
     When a refusal message for the created CCS case is received
     Then the case is marked as refused

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -11,7 +11,7 @@ Feature: Handle refusal message
 
   Scenario: Refusal message results in CCS case excluded from action plan
     Given a CCS Property Listed event is sent
-    And the CCS Property Listed case is created with case_type "HH"
+    And the CCS Property Listed case is created with address_type "HH"
     And the correct ActionInstruction is sent to FWMT
     When a refusal message for the created CCS case is received
     Then the case is marked as refused

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -133,7 +133,7 @@ def check_census_case_fields(context):
     test_helper.assertTrue(context.case_details['msoa'])
     test_helper.assertTrue(context.case_details['lad'])
     test_helper.assertTrue(context.case_details['id'])
-    test_helper.assertTrue(context.case_details['caseType'])
+    test_helper.assertTrue(context.case_details['addressType'])
     test_helper.assertEqual(context.case_details['surveyType'], "CENSUS")
     test_helper.assertFalse(context.case_details['handDelivery'])
 
@@ -164,7 +164,7 @@ def check_ccs_case_fields(context):
     test_helper.assertFalse(context.ccs_case['msoa'])
     test_helper.assertFalse(context.ccs_case['lad'])
     test_helper.assertTrue(context.ccs_case['id'])
-    test_helper.assertTrue(context.ccs_case['caseType'])
+    test_helper.assertTrue(context.ccs_case['addressType'])
     test_helper.assertFalse(context.ccs_case['handDelivery'])
 
 

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -45,7 +45,7 @@ def send_ccs_property_listed_event_with_refusal(context):
     _send_ccs_case_list_msg_to_rabbit(message)
 
 
-@step('a CCS Property Listed event is sent with an address invalid event and addressType "{address_type}"')
+@step('a CCS Property Listed event is sent with an address invalid event and address type "{address_type}"')
 def send_ccs_property_listed_event_with_invalid_address(context, address_type):
     message = _create_ccs_property_listed_event(context, address_type)
     message['payload']['CCSProperty']['invalidAddress'] = {
@@ -103,7 +103,7 @@ def _send_ccs_case_list_msg_to_rabbit(message):
             routing_key=Config.RABBITMQ_CCS_PROPERTY_LISTING_ROUTING_KEY)
 
 
-@step('the CCS Property Listed case is created with address_type "{address_type}"')
+@step('the CCS Property Listed case is created with address type "{address_type}"')
 @retry(stop_max_attempt_number=10, wait_fixed=1000)
 def check_case_created(context, address_type):
     response = requests.get(f'{caseapi_url}{context.case_id}', params={'caseEvents': True})

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -103,14 +103,14 @@ def _send_ccs_case_list_msg_to_rabbit(message):
             routing_key=Config.RABBITMQ_CCS_PROPERTY_LISTING_ROUTING_KEY)
 
 
-@step('the CCS Property Listed case is created with case_type "{case_type}"')
+@step('the CCS Property Listed case is created with address_type "{address_type}"')
 @retry(stop_max_attempt_number=10, wait_fixed=1000)
-def check_case_created(context, case_type):
+def check_case_created(context, address_type):
     response = requests.get(f'{caseapi_url}{context.case_id}', params={'caseEvents': True})
     test_helper.assertEqual(response.status_code, 200, 'CCS Property Listed case not found')
 
     context.ccs_case = response.json()
-    test_helper.assertEqual(context.ccs_case['caseType'], case_type)
+    test_helper.assertEqual(context.ccs_case['addressType'], address_type)
 
 
 @step("the correct ActionInstruction is sent to FWMT")

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -170,9 +170,9 @@ def _publish_offline_receipt(context, tx_id="3d14675d-a25d-4672-a0fe-b960586653e
 
     context.sent_to_gcp = True
 
-@step('if required a new qid and case are created for address type "{address_type}" address level "{address_level}"'
+@step('if required a new qid and case are created for case type "{case_type}" address level "{address_level}"'
       ' qid type "{qid_type}" and country "{country_code}"')
-def get_new_qid_and_case_as_required(context, address_type, address_level, qid_type, country_code):
+def get_new_qid_and_case_as_required(context, case_type, address_level, qid_type, country_code):
     context.loaded_case = context.case_created_events[0]['payload']['collectionCase']
     # receipting_case will be over written if a child case is created
     context.receipting_case = context.case_created_events[0]['payload']['collectionCase']
@@ -182,7 +182,7 @@ def get_new_qid_and_case_as_required(context, address_type, address_level, qid_t
         return
 
     if qid_type == 'Ind':
-        if address_type == 'HI':
+        if case_type == 'HI':
             request_hi_individual_telephone_capture(context, "HH", country_code)
             context.qid_to_receipt = context.telephone_capture_qid_uac['questionnaireId']
             context.receipting_case = _get_emitted_case(context, 'CASE_CREATED')
@@ -193,7 +193,7 @@ def get_new_qid_and_case_as_required(context, address_type, address_level, qid_t
 
             return
         else:
-            request_individual_telephone_capture(context, address_type, country_code)
+            request_individual_telephone_capture(context, case_type, country_code)
             context.qid_to_receipt = context.telephone_capture_qid_uac['questionnaireId']
             check_correct_uac_updated_message_is_emitted(context)
             return
@@ -214,8 +214,8 @@ def send_receipt(context):
 
 
 @step('if the actual response count is incremented "{incremented}" or the case is marked receipted "{receipted}" '
-      'then there should be a case updated message of address type "{address_type}"')
-def check_ce_actual_responses_and_receipted(context, incremented, receipted, address_type):
+      'then there should be a case updated message of case type "{case_type}"')
+def check_ce_actual_responses_and_receipted(context, incremented, receipted, case_type):
     if receipted == 'False' and incremented == 'False':
         # The case has not changed, so there's nothing to see here
         check_no_msgs_sent_to_queue(Config.RABBITMQ_RH_OUTBOUND_CASE_QUEUE,
@@ -228,7 +228,7 @@ def check_ce_actual_responses_and_receipted(context, incremented, receipted, add
     test_helper.assertEqual(emitted_case['id'], context.receipting_case['id'])
 
     # ceActualResponses is not set on HI cases
-    if address_type != "HI":
+    if case_type != "HI":
         expected_actual_responses = context.receipting_case['ceActualResponses']
 
         if incremented == 'True':

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -68,7 +68,7 @@ def uac_updated_msg_emitted(context):
     test_helper.assertFalse(emitted_uac['active'])
 
 
-@step('a CLOSE action instruction is sent to field work management with addressType "{address_type}"')
+@step('a CLOSE action instruction is sent to field work management with address type "{address_type}"')
 def action_close_sent_to_fwm(context, address_type):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE, functools.partial(
@@ -170,9 +170,9 @@ def _publish_offline_receipt(context, tx_id="3d14675d-a25d-4672-a0fe-b960586653e
 
     context.sent_to_gcp = True
 
-@step('if required a new qid and case are created for case type "{case_type}" address level "{address_level}"'
+@step('if required a new qid and case are created for address type "{address_type}" address level "{address_level}"'
       ' qid type "{qid_type}" and country "{country_code}"')
-def get_new_qid_and_case_as_required(context, case_type, address_level, qid_type, country_code):
+def get_new_qid_and_case_as_required(context, address_type, address_level, qid_type, country_code):
     context.loaded_case = context.case_created_events[0]['payload']['collectionCase']
     # receipting_case will be over written if a child case is created
     context.receipting_case = context.case_created_events[0]['payload']['collectionCase']
@@ -182,7 +182,7 @@ def get_new_qid_and_case_as_required(context, case_type, address_level, qid_type
         return
 
     if qid_type == 'Ind':
-        if case_type == 'HI':
+        if address_type == 'HI':
             request_hi_individual_telephone_capture(context, "HH", country_code)
             context.qid_to_receipt = context.telephone_capture_qid_uac['questionnaireId']
             context.receipting_case = _get_emitted_case(context, 'CASE_CREATED')
@@ -193,7 +193,7 @@ def get_new_qid_and_case_as_required(context, case_type, address_level, qid_type
 
             return
         else:
-            request_individual_telephone_capture(context, case_type, country_code)
+            request_individual_telephone_capture(context, address_type, country_code)
             context.qid_to_receipt = context.telephone_capture_qid_uac['questionnaireId']
             check_correct_uac_updated_message_is_emitted(context)
             return
@@ -214,8 +214,8 @@ def send_receipt(context):
 
 
 @step('if the actual response count is incremented "{incremented}" or the case is marked receipted "{receipted}" '
-      'then there should be a case updated message of case type "{case_type}"')
-def check_ce_actual_responses_and_receipted(context, incremented, receipted, case_type):
+      'then there should be a case updated message of address type "{address_type}"')
+def check_ce_actual_responses_and_receipted(context, incremented, receipted, address_type):
     if receipted == 'False' and incremented == 'False':
         # The case has not changed, so there's nothing to see here
         check_no_msgs_sent_to_queue(Config.RABBITMQ_RH_OUTBOUND_CASE_QUEUE,
@@ -228,7 +228,7 @@ def check_ce_actual_responses_and_receipted(context, incremented, receipted, cas
     test_helper.assertEqual(emitted_case['id'], context.receipting_case['id'])
 
     # ceActualResponses is not set on HI cases
-    if case_type != "HI":
+    if address_type != "HI":
         expected_actual_responses = context.receipting_case['ceActualResponses']
 
         if incremented == 'True':

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -13,11 +13,11 @@ from config import Config
 
 
 @step('there is a request for telephone capture for an address level "{address_level}" case '
-      'with case type "{case_type}" and country "{country_code}"')
-def request_telephone_capture_qid_uac(context, address_level, case_type, country_code):
+      'with address type "{address_type}" and country "{country_code}"')
+def request_telephone_capture_qid_uac(context, address_level, address_type, country_code):
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
     context.fulfilment_requested_case_id = context.case_created_events[0]['payload']['collectionCase']['id']
-    _check_case_type_country_address_level(context.first_case, case_type, country_code, address_level=address_level)
+    _check_address_type_country_address_level(context.first_case, address_type, country_code, address_level=address_level)
     response = requests.get(f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid")
     test_helper.assertEqual(response.status_code, 200)
 
@@ -25,11 +25,11 @@ def request_telephone_capture_qid_uac(context, address_level, case_type, country
 
 
 @step('there is a request for individual telephone capture for the case '
-      'with case type "{case_type}" and country "{country_code}"')
-def request_individual_telephone_capture(context, case_type, country_code):
+      'with address type "{address_type}" and country "{country_code}"')
+def request_individual_telephone_capture(context, address_type, country_code):
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
     context.fulfilment_requested_case_id = context.case_created_events[0]['payload']['collectionCase']['id']
-    _check_case_type_country(context.first_case, case_type, country_code)
+    _check_address_type_country(context.first_case, address_type, country_code)
 
     response = requests.get(
         f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid?individual=true")
@@ -39,7 +39,7 @@ def request_individual_telephone_capture(context, case_type, country_code):
 
 
 @step('there is a request for a new HI case for telephone capture for the parent case '
-      'with case type "{case_type}" and country "{country_code}"')
+      'with address type "{address_type}" and country "{country_code}"')
 def request_hi_individual_telephone_capture(context, case_type, country_code):
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
     context.telephone_capture_parent_case_id = context.first_case['id']

--- a/acceptance_tests/features/steps/telephone_capture.py
+++ b/acceptance_tests/features/steps/telephone_capture.py
@@ -17,7 +17,8 @@ from config import Config
 def request_telephone_capture_qid_uac(context, address_level, address_type, country_code):
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
     context.fulfilment_requested_case_id = context.case_created_events[0]['payload']['collectionCase']['id']
-    _check_address_type_country_address_level(context.first_case, address_type, country_code, address_level=address_level)
+    _check_address_type_country_address_level(context.first_case, address_type, country_code,
+                                              address_level=address_level)
     response = requests.get(f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid")
     test_helper.assertEqual(response.status_code, 200)
 
@@ -40,11 +41,11 @@ def request_individual_telephone_capture(context, address_type, country_code):
 
 @step('there is a request for a new HI case for telephone capture for the parent case '
       'with address type "{address_type}" and country "{country_code}"')
-def request_hi_individual_telephone_capture(context, case_type, country_code):
+def request_hi_individual_telephone_capture(context, address_type, country_code):
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
     context.telephone_capture_parent_case_id = context.first_case['id']
     context.individual_case_id = str(uuid.uuid4())
-    _check_case_type_country_address_level(context.first_case, case_type, country_code)
+    _check_address_type_country_address_level(context.first_case, address_type, country_code)
     response = requests.get(
         f"{Config.CASEAPI_SERVICE}/cases/{context.first_case['id']}/qid"
         f"?individual=true"
@@ -54,17 +55,17 @@ def request_hi_individual_telephone_capture(context, case_type, country_code):
     context.telephone_capture_qid_uac = response.json()
 
 
-def _check_case_type_country_address_level(case, case_type, country_code, address_level='U'):
-    _check_case_type_country(case, case_type, country_code)
+def _check_address_type_country_address_level(case, address_type, country_code, address_level='U'):
+    _check_address_type_country(case, address_type, country_code)
     test_helper.assertEqual(address_level, case['address']['addressLevel'],
                             'Loaded case does does not have unit address level')
 
 
-def _check_case_type_country(case, case_type, country_code):
+def _check_address_type_country(case, address_type, country_code):
     test_helper.assertEqual(country_code, case['treatmentCode'][-1],
                             'Loaded case does not match expected nationality')
-    test_helper.assertEqual(case_type, case['treatmentCode'].split('_')[0],
-                            'Loaded case does not match expected case type')
+    test_helper.assertEqual(address_type, case['treatmentCode'].split('_')[0],
+                            'Loaded case does not match expected address type')
 
 
 @step('a UAC and QID with questionnaire type "{questionnaire_type}" type are generated and returned')

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -5,36 +5,36 @@ Feature: Telephone capture
 
   Scenario Outline: Generate and link correct QID type for non individual telephone capture requests
     Given sample file "<sample file>" is loaded successfully
-    When there is a request for telephone capture for an address level "<address level>" case with case type "<case type>" and country "<country code>"
+    When there is a request for telephone capture for an address level "<address level>" case with address type "<address type>" and country "<country code>"
     Then a UAC and QID with questionnaire type "<questionnaire type>" type are generated and returned
     And a UAC updated event is emitted linking the new UAC and QID to the requested case
     And a fulfilment request event is logged
 
     Examples:
-      | sample file                    | address level | case type | country code | questionnaire type |
-      | sample_1_english_HH_unit.csv   | U             | HH        | E            | 01                 |
-      | sample_1_welsh_HH_unit.csv     | U             | HH        | W            | 02                 |
-      | sample_1_ni_HH_unit.csv        | U             | HH        | N            | 04                 |
-      | sample_1_english_CE_estab.csv  | E             | CE        | E            | 31                 |
-      | sample_1_welsh_CE_estab.csv    | E             | CE        | W            | 32                 |
-      | sample_1_ni_CE_estab.csv       | E             | CE        | N            | 34                 |
-      | sample_1_english_SPG_unit.csv  | U             | SPG       | E            | 01                 |
-      | sample_1_welsh_SPG_unit.csv    | U             | SPG       | W            | 02                 |
-      | sample_1_english_SPG_estab.csv | E             | SPG       | E            | 01                 |
-      | sample_1_welsh_SPG_estab.csv   | E             | SPG       | W            | 02                 |
+      | sample file                    | address level | address type | country code | questionnaire type |
+      | sample_1_english_HH_unit.csv   | U             | HH           | E            | 01                 |
+      | sample_1_welsh_HH_unit.csv     | U             | HH           | W            | 02                 |
+      | sample_1_ni_HH_unit.csv        | U             | HH           | N            | 04                 |
+      | sample_1_english_CE_estab.csv  | E             | CE           | E            | 31                 |
+      | sample_1_welsh_CE_estab.csv    | E             | CE           | W            | 32                 |
+      | sample_1_ni_CE_estab.csv       | E             | CE           | N            | 34                 |
+      | sample_1_english_SPG_unit.csv  | U             | SPG          | E            | 01                 |
+      | sample_1_welsh_SPG_unit.csv    | U             | SPG          | W            | 02                 |
+      | sample_1_english_SPG_estab.csv | E             | SPG          | E            | 01                 |
+      | sample_1_welsh_SPG_estab.csv   | E             | SPG          | W            | 02                 |
 
   Scenario Outline: Generate and link new HI case and correct QID type for HI individual telephone capture requests
     Given sample file "<sample file>" is loaded successfully
-    When there is a request for a new HI case for telephone capture for the parent case with case type "<case type>" and country "<country code>"
+    When there is a request for a new HI case for telephone capture for the parent case with address type "<ad type>" and country "<country code>"
     Then a UAC and QID with questionnaire type "<questionnaire type>" type are generated and returned
     And a new individual child case for telephone capture is emitted to RH and Action Scheduler
     And a UAC updated event is emitted linking the new UAC and QID to the individual case
 
     Examples:
-      | sample file                  | case type | country code | questionnaire type |
-      | sample_1_english_HH_unit.csv | HH        | E            | 21                 |
-      | sample_1_welsh_HH_unit.csv   | HH        | W            | 22                 |
-      | sample_1_ni_HH_unit.csv      | HH        | N            | 24                 |
+      | sample file                  | address type | country code | questionnaire type |
+      | sample_1_english_HH_unit.csv | HH           | E            | 21                 |
+      | sample_1_welsh_HH_unit.csv   | HH           | W            | 22                 |
+      | sample_1_ni_HH_unit.csv      | HH           | N            | 24                 |
 
 
   Scenario Outline: Generate and link correct individual QID type for individual telephone capture requests

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -29,7 +29,7 @@ Feature: Telephone capture
     Then a UAC and QID with questionnaire type "<questionnaire type>" type are generated and returned
     And a new individual child case for telephone capture is emitted to RH and Action Scheduler
     And a UAC updated event is emitted linking the new UAC and QID to the individual case
-sss
+
     Examples:
       | sample file                  | address type | country code | questionnaire type |
       | sample_1_english_HH_unit.csv | HH           | E            | 21                 |
@@ -39,22 +39,22 @@ sss
 
   Scenario Outline: Generate and link correct individual QID type for individual telephone capture requests
     Given sample file "<sample file>" is loaded successfully
-    When there is a request for individual telephone capture for the case with case type "<case type>" and country "<country code>"
+    When there is a request for individual telephone capture for the case with address type "<address type>" and country "<country code>"
     Then a UAC and QID with questionnaire type "<questionnaire type>" type are generated and returned
     And a UAC updated event is emitted linking the new UAC and QID to the requested case
     And a fulfilment request event is logged
 
     Examples:
-      | sample file                    | case type | country code | questionnaire type |
-      | sample_1_english_SPG_unit.csv  | SPG       | E            | 21                 |
-      | sample_1_welsh_SPG_unit.csv    | SPG       | W            | 22                 |
-      | sample_1_ni_SPG_unit.csv       | SPG       | N            | 24                 |
-      | sample_1_english_SPG_estab.csv | SPG       | E            | 21                 |
-      | sample_1_welsh_SPG_estab.csv   | SPG       | W            | 22                 |
-      | sample_1_ni_SPG_estab.csv      | SPG       | N            | 24                 |
-      | sample_1_english_CE_estab.csv  | CE        | E            | 21                 |
-      | sample_1_welsh_CE_estab.csv    | CE        | W            | 22                 |
-      | sample_1_ni_CE_estab.csv       | CE        | N            | 24                 |
-      | sample_1_english_CE_unit.csv   | CE        | E            | 21                 |
-      | sample_1_welsh_CE_unit.csv     | CE        | W            | 22                 |
-      | sample_1_ni_CE_unit.csv        | CE        | N            | 24                 |
+      | sample file                    | address type | country code | questionnaire type |
+      | sample_1_english_SPG_unit.csv  | SPG          | E            | 21                 |
+      | sample_1_welsh_SPG_unit.csv    | SPG          | W            | 22                 |
+      | sample_1_ni_SPG_unit.csv       | SPG          | N            | 24                 |
+      | sample_1_english_SPG_estab.csv | SPG          | E            | 21                 |
+      | sample_1_welsh_SPG_estab.csv   | SPG          | W            | 22                 |
+      | sample_1_ni_SPG_estab.csv      | SPG          | N            | 24                 |
+      | sample_1_english_CE_estab.csv  | CE           | E            | 21                 |
+      | sample_1_welsh_CE_estab.csv    | CE           | W            | 22                 |
+      | sample_1_ni_CE_estab.csv       | CE           | N            | 24                 |
+      | sample_1_english_CE_unit.csv   | CE           | E            | 21                 |
+      | sample_1_welsh_CE_unit.csv     | CE           | W            | 22                 |
+      | sample_1_ni_CE_unit.csv        | CE           | N            | 24                 |

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -25,11 +25,11 @@ Feature: Telephone capture
 
   Scenario Outline: Generate and link new HI case and correct QID type for HI individual telephone capture requests
     Given sample file "<sample file>" is loaded successfully
-    When there is a request for a new HI case for telephone capture for the parent case with address type "<ad type>" and country "<country code>"
+    When there is a request for a new HI case for telephone capture for the parent case with address type "<address type>" and country "<country code>"
     Then a UAC and QID with questionnaire type "<questionnaire type>" type are generated and returned
     And a new individual child case for telephone capture is emitted to RH and Action Scheduler
     And a UAC updated event is emitted linking the new UAC and QID to the individual case
-
+sss
     Examples:
       | sample file                  | address type | country code | questionnaire type |
       | sample_1_english_HH_unit.csv | HH           | E            | 21                 |

--- a/acceptance_tests/features/unaddressed.feature
+++ b/acceptance_tests/features/unaddressed.feature
@@ -13,7 +13,7 @@ Feature: Generating UAC/QID pairs for unaddressed letters & questionnaires
 
   Scenario: Questionnaire linked to unaddressed CCS case
     Given a CCS Property Listed event is sent
-    And the CCS Property Listed case is created with case_type "HH"
+    And the CCS Property Listed case is created with address type "HH"
     When an unaddressed message of questionnaire type 01 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     Then a Questionnaire Linked message is sent for the CCS case


### PR DESCRIPTION
# Motivation and Context
Case in case-api now has both caseType and addressType but we call the addressType "caseType" in the JSON messages we return so it can be confusing

# What has changed
Reference to caseType in ATs has been changed to addressType where applicable
Have also tried to standardise the term address type in the features as they have included address_type and addressType but relate to the same thing

# How to test?
Clone and build from case-api 
Run make test

# Links
https://trello.com/c/FlnWxlG2
https://collaborate2.ons.gov.uk/confluence/display/CATD/Case+API

