### PR TITLE
Change formatting for QID CCS msg

### DIFF
--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -26,9 +26,9 @@ def send_ccs_property_listed_event(context):
 @step("a CCS Property Listed event is sent with a qid")
 def send_ccs_property_listed_event_with_qid(context):
     message = _create_ccs_property_listed_event(context)
-    message['payload']['CCSProperty']['uac'] = {
+    message['payload']['CCSProperty']['uac'] = [{
         "questionnaireId": context.expected_questionnaire_id
-    }
+    }]
 
     _send_ccs_case_list_msg_to_rabbit(message)
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to be able to handle an array of QIDs on CCS Property Listed events

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Change `uac` to allow a list of QIDs

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run the tests against the branch linked below

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/OxvWc8A3/317-handle-multiple-qid-links-for-ccs-property-listings-8

https://github.com/ONSdigital/census-rm-case-processor/pull/120