### PR TITLE
Removal of 404 Status Acceptance Tests

### DIFF
--- a/acceptance_tests/features/case_look_up.feature
+++ b/acceptance_tests/features/case_look_up.feature
@@ -12,18 +12,6 @@ Feature: Case look up for the contact centre
     When sample file "sample_input_england_census_spec.csv" is loaded successfully
     Then a case can be retrieved by its caseRef
 
-  Scenario: Check non-existent caseId returns a 404 status code
-    Given a random caseId is generated
-    Then case API should return a 404 when queried
-
-  Scenario: Check non-existent uprn returns a 404 status code
-    Given a random uprn is generated
-    Then case API should return a 404 when queried
-
-  Scenario: Check non-existent caseRef returns a 404 status code
-    Given a random caseRef is generated
-    Then case API should return a 404 when queried
-
   Scenario: Check case-api returns correct fields for a CENSUS case
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     Then a case can be retrieved from the case API service

--- a/acceptance_tests/features/steps/case_look_up.py
+++ b/acceptance_tests/features/steps/case_look_up.py
@@ -1,10 +1,8 @@
 import json
 import logging
-from random import randint
-from uuid import uuid4
 
 import requests
-from behave import then, given, step
+from behave import then, step
 from structlog import wrap_logger
 
 from acceptance_tests.utilities.test_case_helper import test_helper
@@ -20,34 +18,6 @@ def get_case_by_id(context):
     response = requests.get(f'{case_api_url}{case_id}')
     test_helper.assertEqual(response.status_code, 200, 'Case not found')
     context.case_details = response.json()
-
-
-@given('a random caseId is generated')
-def generate_random_uuid(context):
-    dummy_case_id = uuid4()
-    context.test_endpoint_with_non_existent_value = dummy_case_id
-    logger.info(f'Dummy caseId = {dummy_case_id}')
-
-
-@given('a random uprn is generated')
-def generate_random_uprn(context):
-    random_uprn = randint(15000000000, 19999999999)
-    context.test_endpoint_with_non_existent_value = f'uprn/{random_uprn}'
-    logger.info(f'Dummy uprn = {random_uprn}')
-
-
-@given('a random caseRef is generated')
-def generate_random_case_ref(context):
-    random_case_ref = randint(15000000, 19999999)
-    context.test_endpoint_with_non_existent_value = f'ref/{random_case_ref}'
-    logger.info(f'Dummy caseRef = {random_case_ref}')
-
-
-@then('case API should return a 404 when queried')
-def get_non_existent_case_id(context):
-    response = requests.get(f'{case_api_url}{context.test_endpoint_with_non_existent_value}')
-
-    test_helper.assertEqual(response.status_code, 404, 'A case was returned when none were expected')
 
 
 @then('case API returns multiple cases for a UPRN')


### PR DESCRIPTION
# Motivation and Context
LT found that there is a small chance that the random CaseRef generated in the ATs will produce a number that actually exists rather than one that doesn't. If it produces a CaseRef that exists then it wont throw a 404 status error
These tests are replicated in the case-api IT and unit tests so are deemed unnecessary in the ATs

# What has changed
Removed the test features relating to 404 tests in case_look_up.feature
Removed (now) unused code from case_look_up.py

# How to test?
Clone and run make test 

# Links
https://trello.com/c/lbyx9aZv