### PR TITLE
Remove pipenv check ignore rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ install:
 	pipenv install --dev
 
 package_vulnerability:
-	pipenv check --ignore 37752
+	pipenv check
 
 flake:
 	pipenv run flake8 .


### PR DESCRIPTION
# Motivation and Context
The issue with the CVE rule has been resolved so we can remove the ignore rule

# What has changed
* Remove pipenv check ignore rule

# How to test?
The travis build passing should indicate success, you can also run `make package_vulnerability` locally.

# Links
https://trello.com/c/6pOprjWe/704-remove-pipenv-check-ignore-rule-now-issue-is-fixed