### PR TITLE
Remove test that expected secure estab field to be excluded

### DIFF
--- a/acceptance_tests/features/secure_establishment.feature
+++ b/acceptance_tests/features/secure_establishment.feature
@@ -11,10 +11,3 @@ Feature: Handle Secure Establishments
     When a FIELD action rule for address type "CE" is set when loading queues are drained
     Then the case can be retrieved from the case API service and has a secureEstablishment value of "false"
     And the action instruction is emitted to FWMT where case has a secureEstablishment value of "false"
-
-  Scenario: secureEstablishment is not present when address type is not CE
-    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
-    When a FIELD action rule for address type "HH" is set when loading queues are drained
-    Then the case can be retrieved from the case API service and has a secureEstablishment value of "false"
-    And the action instruction is emitted to FWMT where case has a secureEstablishment value of "none"
-


### PR DESCRIPTION
# Motivation and Context
We're now sending whatever data we have instead of conditioning on case type.

# What has changed
* Remove test which expected secure estab field to be excluded on non CE cases

# How to test?
Run with linked branches

# Links
https://trello.com/c/ELwJGrfA/716-rmc-341-check-spg-cases-against-new-cesecure-column-5
https://github.com/ONSdigital/census-rm-fieldwork-adapter/pull/36