### PR TITLE
updated the refusal message to reflect current changes

### DIFF
--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -37,7 +37,6 @@ def _send_refusal_msg_to_rabbit(case_id):
                         "title": "Mr",
                         "forename": "Test",
                         "surname": "Testing",
-                        "email": None,
                         "telNo": "01234123123"
                     },
                     "address": {
@@ -46,7 +45,8 @@ def _send_refusal_msg_to_rabbit(case_id):
                         "addressLine3": "",
                         "townName": "Test Town",
                         "postcode": "XX1 XX1",
-                        "region": "W"
+                        "region": "W",
+                        "uprn": "123456789143"
                     }
                 }
             }


### PR DESCRIPTION
# Motivation and Context
The refusal message spec has been update, whilst no RM code has to change we should reflect these changes in our acceptance tests

# What has changed
Test refusal message has had the "email" field removed from the contact block and "uprn" field added to the address block

# How to test?
check out this branch and run the tests and they should all pass