### PR TITLE
Changed CLOSE to CANCEL

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -4,7 +4,7 @@ Feature: Address updates
     Given sample file "<sample file>" is loaded successfully
     When an invalid address message is sent from "CC"
     Then a case_updated msg is emitted where "addressInvalid" is "True"
-    And a CLOSE action instruction is sent to field work management with address type "<address type>"
+    And a CANCEL action instruction is sent to field work management with address type "<address type>"
     And the case event log records invalid address
 
     Examples:
@@ -18,7 +18,7 @@ Feature: Address updates
     Given sample file "<sample file>" is loaded successfully
     When an invalid address message is sent from "CC"
     Then a case_updated msg is emitted where "addressInvalid" is "True"
-    And a CLOSE action instruction is sent to field work management with address type "<address type>"
+    And a CANCEL action instruction is sent to field work management with address type "<address type>"
     And the case event log records invalid address
 
     Examples:
@@ -32,7 +32,7 @@ Feature: Address updates
     And the correct ActionInstruction is sent to FWMT
     When an invalid address message for the CCS case is sent from "CC"
     Then a case_updated msg is emitted where "addressInvalid" is "True"
-    And a CLOSE action instruction is sent to field work management with address type "HH"
+    And a CANCEL action instruction is sent to field work management with address type "HH"
     And the case event log records invalid address
 
 
@@ -49,7 +49,7 @@ Feature: Address updates
     Then events logged against the case are [SAMPLE_LOADED,ADDRESS_MODIFIED]
 
 
-  Scenario:  Log AddressTypeChanged event
+  Scenario: Log AddressTypeChanged event
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When an AddressTypeChanged event is sent
     And events logged against the case are [SAMPLE_LOADED,ADDRESS_TYPE_CHANGED]

--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -10,18 +10,18 @@ Feature: Case processor handles receipt message from pubsub service
     And if the field instruction "<instruction>" is not NONE a msg to field is emitted where ceActualResponse is incremented "<increment>"
 
     Examples:
-      | case type    | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
-      | HH           | U             | HH       | False     | True    | CLOSE       | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | HH           | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
-      | HI           | U             | Ind      | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | FULFILMENT_REQUESTED,SAMPLE_LOADED                                                      | RESPONSE_RECEIVED,RM_UAC_CREATED |
-      | CE           | E             | Ind      | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | CE           | E             | CE1      | False     | True    | UPDATE      | sample_1_english_CE_estab.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | CE           | U             | Ind      | True      | AR >= E | CLOSE       | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | SPG          | E             | HH       | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | SPG          | E             | Ind      | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | SPG          | U             | HH       | False     | True    | CLOSE       | sample_1_english_SPG_unit.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | SPG          | U             | Ind      | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | SPG          | U             | Cont     | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
+      | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
+      | HH        | U             | HH       | False     | True    | CANCEL      | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
+      | HH        | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
+      | HI        | U             | Ind      | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | FULFILMENT_REQUESTED,SAMPLE_LOADED                                                      | RESPONSE_RECEIVED,RM_UAC_CREATED |
+      | CE        | E             | Ind      | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
+      | CE        | E             | CE1      | False     | True    | UPDATE      | sample_1_english_CE_estab.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
+      | CE        | U             | Ind      | True      | AR >= E | CANCEL      | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
+      | SPG       | E             | HH       | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
+      | SPG       | E             | Ind      | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
+      | SPG       | U             | HH       | False     | True    | CANCEL      | sample_1_english_SPG_unit.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
+      | SPG       | U             | Ind      | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
+      | SPG       | U             | Cont     | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
 
 
   Scenario: Receipted Cases are excluded from print files
@@ -46,7 +46,7 @@ Feature: Case processor handles receipt message from pubsub service
     When the receipt msg for the created CCS case is put on the GCP pubsub
     Then a uac_updated msg is emitted with active set to false
     And a case_updated msg is emitted where "receiptReceived" is "True"
-    And a CLOSE action instruction is sent to field work management with address type "HH"
+    And a CANCEL action instruction is sent to field work management with address type "HH"
     And the events logged for the receipted case are [CCS_ADDRESS_LISTED,RESPONSE_RECEIVED]
 
   Scenario: PQRS receipt results in UAC updated event sent to RH
@@ -54,7 +54,7 @@ Feature: Case processor handles receipt message from pubsub service
     When the offline receipt msg for the created case is put on the GCP pubsub
     Then a uac_updated msg is emitted with active set to false
     And a case_updated msg is emitted where "receiptReceived" is "True"
-    And a CLOSE action instruction is sent to field work management with address type "HH"
+    And a CANCEL action instruction is sent to field work management with address type "HH"
     And the events logged for the receipted case are [SAMPLE_LOADED,RESPONSE_RECEIVED]
 
   Scenario: PQRS receipt for continuation questionnaire from fulfilment does not send to Field

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -6,7 +6,7 @@ Feature: Handle refusal message
     And set action rule of type "ICL1E" when case event "REFUSAL_RECEIVED" is logged
     Then only unrefused cases appear in "P_IC_ICL1" print files
     And the case is marked as refused
-    And a CLOSE action instruction is emitted to FWMT
+    And a CANCEL action instruction is emitted to FWMT
     And the events logged for the refusal case are [SAMPLE_LOADED,REFUSAL_RECEIVED]
 
   Scenario: Refusal message results in CCS case excluded from action plan
@@ -15,5 +15,5 @@ Feature: Handle refusal message
     And the correct ActionInstruction is sent to FWMT
     When a refusal message for the created CCS case is received
     Then the case is marked as refused
-    And a CLOSE action instruction is emitted to FWMT
+    And a CANCEL action instruction is emitted to FWMT
     And the events logged for the refusal case are [CCS_ADDRESS_LISTED,REFUSAL_RECEIVED]

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -68,15 +68,15 @@ def uac_updated_msg_emitted(context):
     test_helper.assertFalse(emitted_uac['active'])
 
 
-@step('a CLOSE action instruction is sent to field work management with address type "{address_type}"')
-def action_close_sent_to_fwm(context, address_type):
+@step('a CANCEL action instruction is sent to field work management with address type "{address_type}"')
+def action_cancel_sent_to_fwm(context, address_type):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE, functools.partial(
-        _field_work_close_callback, context=context))
+        _field_work_cancel_callback, context=context))
 
     test_helper.assertEqual(context.fwmt_emitted_case_id, context.first_case["id"])
     test_helper.assertEqual(context.addressType, address_type)
-    test_helper.assertEqual(context.field_action_close_message['surveyName'], context.first_case['survey'])
+    test_helper.assertEqual(context.field_action_cancel_message['surveyName'], context.first_case['survey'])
 
 
 @step("the offline receipt msg for a continuation form from the case is received")
@@ -94,17 +94,17 @@ def case_updated_msg_sent_with_values(context, case_field, expected_field_value)
     test_helper.assertEqual(str(emitted_case[case_field]), expected_field_value)
 
 
-def _field_work_close_callback(ch, method, _properties, body, context):
-    action_close = json.loads(body)
+def _field_work_cancel_callback(ch, method, _properties, body, context):
+    action_cancel = json.loads(body)
 
-    if not action_close['actionInstruction'] == 'CLOSE':
+    if not action_cancel['actionInstruction'] == 'CANCEL':
         ch.basic_nack(delivery_tag=method.delivery_tag)
         test_helper.fail(f'Unexpected message on {Config.RABBITMQ_OUTBOUND_FIELD_QUEUE} case queue. '
-                         f'Got "{action_close["actionInstruction"]}", wanted "CLOSE"')
+                         f'Got "{action_cancel["actionInstruction"]}", wanted "CANCEL"')
 
-    context.addressType = action_close['addressType']
-    context.fwmt_emitted_case_id = action_close['caseId']
-    context.field_action_close_message = action_close
+    context.addressType = action_cancel['addressType']
+    context.fwmt_emitted_case_id = action_cancel['caseId']
+    context.field_action_cancel_message = action_cancel
     ch.basic_ack(delivery_tag=method.delivery_tag)
     ch.stop_consuming()
 

--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -6,7 +6,7 @@ from behave import step
 from retrying import retry
 
 from acceptance_tests.features.steps.event_log import check_if_event_list_is_exact_match
-from acceptance_tests.features.steps.receipt import _field_work_close_callback
+from acceptance_tests.features.steps.receipt import _field_work_cancel_callback
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue
 from acceptance_tests.utilities.test_case_helper import test_helper
@@ -85,10 +85,10 @@ def check_case_events(context):
     test_helper.fail('Did not find "Refusal Received" event')
 
 
-@step('a CLOSE action instruction is emitted to FWMT')
+@step('a CANCEL action instruction is emitted to FWMT')
 def refusal_received(context):
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE,
-                                    functools.partial(_field_work_close_callback, context=context))
+                                    functools.partial(_field_work_cancel_callback, context=context))
 
     test_helper.assertEqual(context.fwmt_emitted_case_id, context.refused_case_id)
     test_helper.assertEqual(context.addressType, 'HH')


### PR DESCRIPTION
# Motivation and Context
Better wording - less ambiguous 

# What has changed
Any reference to a CLOSE event has been changed to CANCEL

# How to test?
Clone branches for case-processor/fieldwork-adapter, build the image then run the ATs
Check rabbit messages for a CANCEL event now

# Links
https://trello.com/c/3PljKzC2/770-change-field-close-message-to-cancels-5
