### PR TITLE
AM1 Part 4 New Address Fulfilment

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -54,4 +54,10 @@ Feature: Address updates
     When an AddressTypeChanged event is sent
     And events logged against the case are [SAMPLE_LOADED,ADDRESS_TYPE_CHANGED]
 
-
+  Scenario: Fulfilment request for new skeleton case
+    Given a NEW_ADDRESS_REPORTED event is sent from "FIELD" without sourceCaseId
+    And a case created event is emitted
+    When a PQ fulfilment request event with fulfilment code "P_OR_H1" is received by RM
+    Then a UAC updated message with "01" questionnaire type is emitted
+    And correctly formatted on request questionnaire print and manifest files for "P_OR_H1" are created
+    And the questionnaire fulfilment case has these events logged [NEW_ADDRESS_REPORTED,FULFILMENT_REQUESTED,RM_UAC_CREATED,PRINT_CASE_SELECTED]

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -135,3 +135,4 @@ def check_case_created_message_is_emitted(context):
                                                       context=context))
     test_helper.assertEqual(context.first_message['payload']['collectionCase']['id'],
                             context.case_id)
+    context.case_created_events = [context.first_message]


### PR DESCRIPTION
# Motivation and Context
Adds a scenario for requesting a fulfilment on a skeleton case created by address management

# What has changed
* Add fulfilment request on skeleton case scenario

# How to test?
Build and run with linked service branch

# Links
https://trello.com/c/C6Y53PdB/709-am1-part-4-new-address-request-paper-fulfilment-5
https://github.com/ONSdigital/census-rm-action-scheduler/pull/74