### PR TITLE
Add rows count attribute to manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ install:
 	pipenv install --dev
 
 package_vulnerability:
-	pipenv check
+	# TODO reinstate this once https://github.com/pypa/pipenv/issues/4188 is resolved
+	#pipenv check
 
 flake:
 	pipenv run flake8 .

--- a/acceptance_tests/features/steps/print_file.py
+++ b/acceptance_tests/features/steps/print_file.py
@@ -145,6 +145,7 @@ def _get_matching_manifest_file(filename, files):
 def _create_expected_manifest(sftp_utility, csv_file, created_datetime, pack_code):
     actual_file_contents = sftp_utility.get_file_contents_as_string(f'{PACK_CODE_TO_SFTP_DIRECTORY[pack_code]}'
                                                                     f'/{csv_file.filename}')
+    decrypted_file_contents = sftp_utility.decrypt_message(actual_file_contents)
 
     md5_hash = hashlib.md5(actual_file_contents.encode('utf-8')).hexdigest()
     expected_size = sftp_utility.get_file_size(f'{PACK_CODE_TO_SFTP_DIRECTORY[pack_code]}/{csv_file.filename}')
@@ -154,7 +155,7 @@ def _create_expected_manifest(sftp_utility, csv_file, created_datetime, pack_cod
         md5sum=md5_hash,
         relativePath='./',
         name=csv_file.filename,
-        rows=len(actual_file_contents.splitlines())
+        rows=len(decrypted_file_contents.splitlines())
     )
 
     manifest = dict(

--- a/acceptance_tests/features/steps/print_file.py
+++ b/acceptance_tests/features/steps/print_file.py
@@ -2,9 +2,8 @@ import hashlib
 import json
 import logging
 
-from google.cloud import storage
-
 from behave import then, step
+from google.cloud import storage
 from retrying import retry
 from structlog import wrap_logger
 
@@ -154,7 +153,8 @@ def _create_expected_manifest(sftp_utility, csv_file, created_datetime, pack_cod
         sizeBytes=str(expected_size),
         md5sum=md5_hash,
         relativePath='./',
-        name=csv_file.filename
+        name=csv_file.filename,
+        rows=len(actual_file_contents.splitlines())
     )
 
     manifest = dict(


### PR DESCRIPTION
# Motivation and Context
The rows count is now required on the print file manifest so the AT's need to be checking it. 

# What has changed
*  Check the print file manifest rows count attribute
* Temporarily disable pipenv check

# How to test?
Run against linked branches

# Links
https://trello.com/c/Ole04jk0/735-add-rows-count-attribute-to-manifest-5
https://github.com/ONSdigital/census-rm-print-file-service/pull/31
https://github.com/ONSdigital/census-rm-qid-batch-runner/pull/37