### PR TITLE
AM1 7.1 new address HI telephone capture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,13 @@ flake:
 
 test: package_vulnerability flake at_tests
 
+smoke_test: package_vulnerability flake run_smoke_tests
+
 at_tests:
 	SFTP_KEY_FILENAME=dummy_sftp_private_key PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run python run.py --log_level WARN
+
+run_smoke_tests:
+	SFTP_KEY_FILENAME=dummy_sftp_private_key PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run behave acceptance_tests/features --logging-level WARN --tags=@smoke --format=progress2
 
 build:
 	docker build -t eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests .

--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@ Python Behave BDD tests for RM Census.
     ```bash
     make test
     ```
+   
+### Smoke tests
+A subset of the tests have been tagged with `@smoke` to quickly test most domains of RM.
+
+Run them locally with 
+```shell script
+make smoke_test
+```
 
 ## Run tests against a GCP project
 
 Run the `run_gke.sh` bash script with the environment variables (defined in [the table below](#script-environment-variables)).
-
-### Examples
 
 NB: assumes infrastructure and services exist in respective projects.
 
@@ -34,21 +40,20 @@ To run the acceptance tests (`latest` image in GCR) in a pod in census-rm-ci:
 ```bash
 ./run_gke.sh
 ```
-To run a locally-modified version of the acceptance tests in a pod in a dev GCP project (builds and pushes the docker image to the project's GCR):
-```bash
-BUILD=true ENV=test-env ./run_gke.sh
+To run a locally-modified version of the acceptance tests in a pod you will have to build and tag the image, push it to the GCR and change the image in [acceptance_tests_pod.yml](./acceptance_tests_pod.yml) to point to your modified image
+```shell script
+IMAGE_TAG=<YOUR_TAG>
+make build
+docker tag eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests:latest eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests:$IMAGE_TAG
+docker push eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests:$IMAGE_TAG
 ```
-To run the acceptance tests using the `latest` image from the census-rm-ci GCR in a pod in a dev GCP project (otherwise defaults to the image in the project's GCR):
+
+Then run the tests with the run GKE script
+
+### Smoke tests
+Run only the tagged smoke tests in a GCP environment with
 ```bash
-IMAGE=ci ENV=test-env ./run_gke.sh
-```
-Build and push a locally-modified version of the acceptance tests and then run in a pod in another dev GCP project:
-```bash
-BUILD=true IMAGE="eu.gcr.io/census-rm-at/rm/census-rm-acceptance-tests:latest" ENV=test-env ./run_gke.sh
-```
-To run the acceptance tests against a different branch of the QID batch runner:
-```bash
-QID_BATCH_BRANCH=<branch> ./run_gke.sh
+ENV=your-test-env SMOKE=true ./run_gke.sh
 ```
 
 ### Script Environment variables
@@ -56,10 +61,8 @@ QID_BATCH_BRANCH=<branch> ./run_gke.sh
 | Name                  | Description                                                                                                                                                                                                  | Example                                  | Default              | Required |
 |-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|----------------------|----------|
 | `ENV`                 | The environment to run the tests in and against, it will try to use an existing project of the form `census-rm-<ENV>`. If not present, the script will use the current k8s context.                                                                                                  | `ENV=test-env`                           | None                 | no      |
-| `IMAGE`              | The path to the acceptance tests Docker image to use in the k8s pod (lazy option `ci` to use the default master image).                                                                                                                | `IMAGE="eu.gcr.io/census-rm-test-env/rm/census-rm-acceptance-tests:latest"`                    | `eu.gcr.io/census-rm-$ENV/rm/census-rm-acceptance-tests:latest`                 | no       |
-| `BUILD`          | A boolean (`true` or not set string) to toggle the build and push of the acceptance tests as a Docker image.                                                                                                                  | `IMAGE=true`                        | None              | no       |
-| `NAMESPACE`          | The k8s namespace to run the acceptance tests as a pod in.                                                                                                                  | `NAMESPACE=default`                        | None              | no       |
-
+| `NAMESPACE`          | The k8s namespace to run the acceptance tests as a pod in.                |                                                                                                  | `NAMESPACE=default`                        | None              | no       |
+| `SMOKE`              | A boolean, set to `true` to only run the tagged smoke tests | `SMOKE=true` | `false` | no |
 
 ### Alternatively
 

--- a/acceptance_tests/features/ad_hoc_uac_qid.feature
+++ b/acceptance_tests/features/ad_hoc_uac_qid.feature
@@ -5,9 +5,13 @@ Feature: A UAC/QID pair can be requested for a case
     When a UAC/QID pair is requested with questionnaire type "<questionnaire type>"
     Then a UAC updated message with "<questionnaire type>" questionnaire type is emitted
 
+    @smoke
     Examples: Questionnaire type: <questionnaire type>
       | questionnaire type |
       | 01                 |
+
+    Examples: Questionnaire type: <questionnaire type>
+      | questionnaire type |
       | 02                 |
       | 04                 |
       | 34                 |

--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -86,6 +86,14 @@ Feature: Address updates
     And a UAC updated event is emitted linking the new UAC and QID to the requested case
     And a fulfilment request event is logged
 
+  Scenario: Individual Telephone capture for new skeleton case
+    Given a NEW_ADDRESS_REPORTED event is sent from "FIELD" without sourceCaseId
+    And a case created event is emitted
+    When there is a request for individual telephone capture for the case with address type "SPG" and country "E"
+    Then a UAC and QID with questionnaire type "21" type are generated and returned
+    And a UAC updated event is emitted linking the new UAC and QID to the requested case
+    And a fulfilment request event is logged
+
   Scenario: New address event received with sourceCaseId and sends Create to Field
     Given sample file "sample_1_english_SPG_estab.csv" is loaded successfully
     When a NEW_ADDRESS_REPORTED event is sent from "FIELD" with sourceCaseId

--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -70,7 +70,6 @@ Feature: Address updates
     When an AddressTypeChanged event is sent
     And events logged against the case are [SAMPLE_LOADED,ADDRESS_TYPE_CHANGED]
 
-  @smoke
   Scenario: Fulfilment request for new skeleton case
     Given a NEW_ADDRESS_REPORTED event is sent from "FIELD" without sourceCaseId
     And a case created event is emitted

--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -70,6 +70,7 @@ Feature: Address updates
     When an AddressTypeChanged event is sent
     And events logged against the case are [SAMPLE_LOADED,ADDRESS_TYPE_CHANGED]
 
+  @smoke
   Scenario: Fulfilment request for new skeleton case
     Given a NEW_ADDRESS_REPORTED event is sent from "FIELD" without sourceCaseId
     And a case created event is emitted

--- a/acceptance_tests/features/bad_message.feature
+++ b/acceptance_tests/features/bad_message.feature
@@ -1,5 +1,6 @@
 Feature: identify bad messages
 
+  @smoke
   @clear_for_bad_messages
   Scenario: Bad messages on RM queues are put on redelivery queue
     Given a bad message is placed on each of the queues

--- a/acceptance_tests/features/blank_questionnaire.feature
+++ b/acceptance_tests/features/blank_questionnaire.feature
@@ -14,9 +14,13 @@ Feature: Handling Blank Questionnaire Scenario
     And the correct events are logged for loaded case events "[<loaded case events>]" and individual case events "[<individual case events>]"
     And if the field instruction "<blank instruction>" is not NONE a msg to field is emitted
 
+    @smoke
     Examples:
       | case type | address level | qid type | form type | sample file                   | loaded case events                                               | blank instruction | another qid receipted | country | offline receipt instruction | individual case events                             |
       | HH        | U             | HH       | 01        | sample_1_english_HH_unit.csv  | SAMPLE_LOADED,RESPONSE_RECEIVED,RESPONSE_RECEIVED                | UPDATE            | False                 | E       | CANCEL                      |                                                    |
+
+    Examples:
+      | case type | address level | qid type | form type | sample file                   | loaded case events                                               | blank instruction | another qid receipted | country | offline receipt instruction | individual case events                             |
       | HH        | U             | HH       | 01        | sample_1_english_HH_unit.csv  | SAMPLE_LOADED,RM_UAC_CREATED,RESPONSE_RECEIVED,RESPONSE_RECEIVED | NONE              | True                  | E       | CANCEL                      |                                                    |
       | SPG       | U             | HH       | 01        | sample_1_english_SPG_unit.csv | SAMPLE_LOADED,RESPONSE_RECEIVED,RESPONSE_RECEIVED                | UPDATE            | False                 | E       | CANCEL                      |                                                    |
       | SPG       | U             | HH       | 01        | sample_1_english_SPG_unit.csv | SAMPLE_LOADED,RM_UAC_CREATED,RESPONSE_RECEIVED,RESPONSE_RECEIVED | NONE              | True                  | E       | CANCEL                      |                                                    |

--- a/acceptance_tests/features/case_look_up.feature
+++ b/acceptance_tests/features/case_look_up.feature
@@ -1,3 +1,4 @@
+@smoke
 Feature: Case look up for the contact centre
 
   Scenario: Find case by caseId

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -7,6 +7,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
     And the case API returns the CCS QID for the new case
     And the case API returns the new CCS case by postcode search
 
+  @smoke
   Scenario: Log event when a CCS Property Listed event is received with a qid
     When an unaddressed message of questionnaire type 71 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler

--- a/acceptance_tests/features/field_reminder.feature
+++ b/acceptance_tests/features/field_reminder.feature
@@ -1,5 +1,6 @@
 Feature: Reminder messages are emitted to Field Work Management Tool
 
+  @smoke
   Scenario: Tranche 2 household case details to be sent to the Field Work Management Tool
     Given sample file "sample_for_print_stories.csv" is loaded successfully
     And set action rule of type "FIELD" when the case loading queues are drained

--- a/acceptance_tests/features/fulfilment_request.feature
+++ b/acceptance_tests/features/fulfilment_request.feature
@@ -1,5 +1,6 @@
 Feature: Handle fulfilment request events
 
+  @smoke
   Scenario: Log event when a fulfilment request event is received
     Given sample file "sample_input_england_census_spec.csv" is loaded
     And messages are emitted to RH and Action Scheduler with [01] questionnaire types
@@ -23,6 +24,11 @@ Feature: Handle fulfilment request events
     Then a UAC updated message with "<questionnaire type>" questionnaire type is emitted
     And correctly formatted on request questionnaire print and manifest files for "<fulfilment code>" are created
     And the questionnaire fulfilment case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED,PRINT_CASE_SELECTED]
+
+    @smoke
+    Examples: Questionnaire: <fulfilment code>
+      | fulfilment code | questionnaire type |
+      | P_OR_H1         | 01                 |
 
     Examples: Questionnaire: <fulfilment code>
       | fulfilment code | questionnaire type |

--- a/acceptance_tests/features/print_file.feature
+++ b/acceptance_tests/features/print_file.feature
@@ -9,17 +9,21 @@ Feature: Scheduled print and manifest files can be generated and uploaded
     And events logged against the case are [PRINT_CASE_SELECTED,SAMPLE_LOADED]
     And the files have all been copied to the bucket
 
+    @smoke
     Examples: Initial contact letter: <pack code>
-      | pack code      | action type | questionnaire types | sample file                          |
-      | P_IC_ICL1      | ICL1E       | [01]                | sample_input_england_census_spec.csv |
-      | P_IC_ICL2B     | ICL2W       | [02]                | sample_input_wales_census_spec.csv   |
-      | P_IC_ICL4      | ICL4N       | [04]                | sample_input_ni_census_spec.csv      |
-      | D_CE1A_ICLCR1  | CE1_IC01    | [31]                | sample_1_english_CE_estab.csv        |
-      | D_CE1A_ICLCR2B | CE1_IC02    | [32]                | sample_1_welsh_CE_estab.csv          |
-      | D_ICA_ICLR1    | CE_IC03_1   | [21]                | sample_1_english_CE_unit.csv         |
-      | D_ICA_ICLR2B   | CE_IC04_1   | [22]                | sample_1_welsh_CE_unit.csv           |
-      | P_ICCE_ICL1    | SPG_IC11    | [01]                | sample_1_english_SPG_unit.csv        |
-      | P_ICCE_ICL2B   | SPG_IC12    | [02]                | sample_1_welsh_SPG_unit.csv          |
+      | pack code | action type | questionnaire types | sample file                          |
+      | P_IC_ICL1 | ICL1E       | [01]                | sample_input_england_census_spec.csv |
+
+    Examples: Initial contact letter: <pack code>
+      | pack code      | action type | questionnaire types | sample file                        |
+      | P_IC_ICL2B     | ICL2W       | [02]                | sample_input_wales_census_spec.csv |
+      | P_IC_ICL4      | ICL4N       | [04]                | sample_input_ni_census_spec.csv    |
+      | D_CE1A_ICLCR1  | CE1_IC01    | [31]                | sample_1_english_CE_estab.csv      |
+      | D_CE1A_ICLCR2B | CE1_IC02    | [32]                | sample_1_welsh_CE_estab.csv        |
+      | D_ICA_ICLR1    | CE_IC03_1   | [21]                | sample_1_english_CE_unit.csv       |
+      | D_ICA_ICLR2B   | CE_IC04_1   | [22]                | sample_1_welsh_CE_unit.csv         |
+      | P_ICCE_ICL1    | SPG_IC11    | [01]                | sample_1_english_SPG_unit.csv      |
+      | P_ICCE_ICL2B   | SPG_IC12    | [02]                | sample_1_welsh_SPG_unit.csv        |
 
 
   Scenario Outline: Generate print files and log events for initial contact letters CE Estabs

--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -9,9 +9,13 @@ Feature: Case processor handles receipt message from pubsub service
     And if the actual response count is incremented "<increment>" or the case is marked receipted "<receipt>" then there should be a case updated message of case type "<case type>"
     And if the field instruction "<instruction>" is not NONE a msg to field is emitted where ceActualResponse is incremented "<increment>"
 
+    @smoke
     Examples:
       | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
       | HH        | U             | HH       | False     | True    | CANCEL      | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
+
+    Examples:
+      | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
       | HH        | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
       | HI        | U             | Ind      | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | FULFILMENT_REQUESTED,SAMPLE_LOADED                                                      | RESPONSE_RECEIVED,RM_UAC_CREATED |
       | CE        | E             | Ind      | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |

--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -9,13 +9,9 @@ Feature: Case processor handles receipt message from pubsub service
     And if the actual response count is incremented "<increment>" or the case is marked receipted "<receipt>" then there should be a case updated message of case type "<case type>"
     And if the field instruction "<instruction>" is not NONE a msg to field is emitted where ceActualResponse is incremented "<increment>"
 
-    @smoke
     Examples:
       | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
       | HH        | U             | HH       | False     | True    | CANCEL      | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-
-    Examples:
-      | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
       | HH        | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
       | HI        | U             | Ind      | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | FULFILMENT_REQUESTED,SAMPLE_LOADED                                                      | RESPONSE_RECEIVED,RM_UAC_CREATED |
       | CE        | E             | Ind      | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
@@ -53,6 +49,7 @@ Feature: Case processor handles receipt message from pubsub service
     And a CANCEL action instruction is sent to field work management with address type "HH"
     And the events logged for the receipted case are [CCS_ADDRESS_LISTED,RESPONSE_RECEIVED]
 
+  @smoke
   Scenario: PQRS receipt results in UAC updated event sent to RH
     Given sample file "sample_for_receipting.csv" is loaded successfully
     When the offline receipt msg for the created case is put on the GCP pubsub

--- a/acceptance_tests/features/refusal.feature
+++ b/acceptance_tests/features/refusal.feature
@@ -9,6 +9,7 @@ Feature: Handle refusal message
     And a CANCEL action instruction is emitted to FWMT
     And the events logged for the refusal case are [SAMPLE_LOADED,REFUSAL_RECEIVED]
 
+  @smoke
   Scenario: Refusal message results in CCS case excluded from action plan
     Given a CCS Property Listed event is sent
     And the CCS Property Listed case is created with address type "HH"

--- a/acceptance_tests/features/secure_establishment.feature
+++ b/acceptance_tests/features/secure_establishment.feature
@@ -1,5 +1,6 @@
 Feature: Handle Secure Establishments
 
+  @smoke
   Scenario: Marking a case as secureEstablishment is reflected in RM
     Given sample file "sample_1_english_CE_secure_estab.csv" is loaded successfully
     When a FIELD action rule for address type "CE" is set when loading queues are drained

--- a/acceptance_tests/features/secure_establishment.feature
+++ b/acceptance_tests/features/secure_establishment.feature
@@ -1,6 +1,5 @@
 Feature: Handle Secure Establishments
 
-  @smoke
   Scenario: Marking a case as secureEstablishment is reflected in RM
     Given sample file "sample_1_english_CE_secure_estab.csv" is loaded successfully
     When a FIELD action rule for address type "CE" is set when loading queues are drained

--- a/acceptance_tests/features/survey_launched.feature
+++ b/acceptance_tests/features/survey_launched.feature
@@ -1,5 +1,6 @@
 Feature: Handle survey launched event
 
+  @smoke
   Scenario: Survey launched message results in case event logged
     Given sample file "sample_for_receipting.csv" is loaded successfully
     When a survey launched for a created case is received

--- a/acceptance_tests/features/telephone_capture.feature
+++ b/acceptance_tests/features/telephone_capture.feature
@@ -10,9 +10,13 @@ Feature: Telephone capture
     And a UAC updated event is emitted linking the new UAC and QID to the requested case
     And a fulfilment request event is logged
 
+    @smoke
     Examples:
       | sample file                    | address level | address type | country code | questionnaire type |
       | sample_1_english_HH_unit.csv   | U             | HH           | E            | 01                 |
+
+    Examples:
+      | sample file                    | address level | address type | country code | questionnaire type |
       | sample_1_welsh_HH_unit.csv     | U             | HH           | W            | 02                 |
       | sample_1_ni_HH_unit.csv        | U             | HH           | N            | 04                 |
       | sample_1_english_CE_estab.csv  | E             | CE           | E            | 31                 |

--- a/acceptance_tests/features/unaddressed.feature
+++ b/acceptance_tests/features/unaddressed.feature
@@ -43,7 +43,7 @@ Feature: Generating UAC/QID pairs for unaddressed letters & questionnaires
     And a Questionnaire Linked event is logged
     And a Questionnaire Unlinked event is logged
 
-
+  @smoke
   @local-docker
   Scenario: Correct print files generated
     When the unaddressed batch is loaded, the print files are generated

--- a/acceptance_tests/features/undelivered.feature
+++ b/acceptance_tests/features/undelivered.feature
@@ -1,5 +1,6 @@
 Feature: We want to deliver mail to the wrong addresses
 
+  @smoke
   Scenario: We deliver some mail to the wrong place and QM knows about it
     Given sample file "sample_for_receipting.csv" is loaded successfully
     When an undelivered mail QM message is put on GCP pubsub

--- a/run_gke.sh
+++ b/run_gke.sh
@@ -3,40 +3,26 @@ set -e
 
 if [ -z "$ENV" ]; then
     echo "No ENV set. Using kubectl current context."
-    if [ -z "$IMAGE" ] || [ "$IMAGE" = "ci" ]; then
-        IMAGE=eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests:latest
-    fi
+
 else
     GCP_PROJECT=census-rm-$ENV
-    if [ -z "$IMAGE" ]; then
-        IMAGE=eu.gcr.io/$GCP_PROJECT/rm/census-rm-acceptance-tests:latest
-    elif [ "$IMAGE" = "ci" ]; then
-        IMAGE=eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests:latest
-    fi
-
     gcloud config set project $GCP_PROJECT
     gcloud container clusters get-credentials rm-k8s-cluster \
         --region europe-west2 \
         --project $GCP_PROJECT
 fi
 
-if [ "$BUILD" = "true" ]; then
-    echo "Building and pushing Docker image [$IMAGE]..."
-    read -p "Are you sure (y/N)? " -n 1 -r
-    if [[ $REPLY =~ ^[Yy]$ ]]; then
-        docker build -t $IMAGE .
-        docker push $IMAGE
-    else
-        exit 1
-    fi
+BEHAVE_TAGS='--tags=~@local-docker'
+if [ "$SMOKE" = "true" ]; then
+    echo "Running only the tagged smoke tests"
+    BEHAVE_TAGS+=' --tags=@smoke'
 fi
 
-echo "Using RM Acceptance Tests image [$IMAGE]."
 if [ "$NAMESPACE" ]; then
     kubectl config set-context $(kubectl config current-context) --namespace=$NAMESPACE
-    echo "Set kubectl namespace for subsequent commands [$NAMESPACE]."
+    echo "NAMESPACE = [$NAMESPACE] Set kubectl namespace for subsequent commands [$NAMESPACE]."
 fi
-echo "Running RM Acceptance Tests [`kubectl config current-context`]..."
+echo "Running RM Acceptance Tests [$(kubectl config current-context)]..."
 
 kubectl delete pod acceptance-tests --wait || true
 
@@ -44,14 +30,13 @@ kubectl apply -f acceptance_tests_pod.yml
 
 kubectl wait --for=condition=Ready pod/acceptance-tests --timeout=200s
 
-kubectl exec -it acceptance-tests -- /bin/bash -c "sleep 2; behave acceptance_tests/features --tags=~@local-docker"
+kubectl exec -it acceptance-tests -- /bin/bash -c "sleep 2; behave acceptance_tests/features $BEHAVE_TAGS"
 
 kubectl delete pod acceptance-tests || true
 
 if [ -z "$QID_BATCH_BRANCH" ]; then
     QID_BATCH_BRANCH=master
 fi
-
 
 # Run acceptance tests for unaddressed batch
 # Pre-delete to avoid unintentionally running with an old image
@@ -60,5 +45,5 @@ kubectl delete deploy qid-batch-runner --force --now || true
 kubectl apply -f ${BATCH_RUNNER_CONFIG}
 kubectl rollout status deploy qid-batch-runner --watch=true
 kubectl exec -it $(kubectl get pods -o name | grep -m1 qid-batch-runner | cut -d'/' -f 2) \
--- /bin/bash /home/qidbatchrunner/run_acceptance_tests.sh
+    -- /bin/bash /home/qidbatchrunner/run_acceptance_tests.sh
 kubectl delete deploy qid-batch-runner --force --now


### PR DESCRIPTION
# Motivation and Context
Individual telephone capture can be requested on newly reported skeleton cases. Also a quality of life improvement with smoke test tags and target to quickly smoke test an environment

# What has changed
* New scenerio for individual telephone capture on new address
* Smoke test tags and run target
* Update README

# How to test?
Run with linked case processor branch
Run `make smoke_test`, it should complete in under 1:30min

# Links
https://trello.com/c/zwSsVjsD/713-am1-part-71-new-address-create-hi-case-for-telephone-capture-3
https://github.com/ONSdigital/census-rm-case-processor/pull/149

# Screenshots (if appropriate):