### PR TITLE
Test to check skeleton cases are excluded from action plans

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -91,3 +91,11 @@ Feature: Address updates
     When a NEW_ADDRESS_REPORTED event is sent from "FIELD" with sourceCaseId
     And a case created event is emitted
     And a CREATE action instruction is sent to field
+
+  Scenario: Skeleton cases are excluded from action rules
+    Given the action_plan_id is the census action_plan_id
+    And sample file "sample_1_english_SPG_unit.csv" is loaded successfully
+    And a NEW_ADDRESS_REPORTED event is sent from "FIELD" with sourceCaseId
+    And a case created event is emitted
+    When set action rule of type "P_RD_2RL1_1"
+    Then skeleton cases do not appear in "P_RD_2RL1_1" print files

--- a/acceptance_tests/features/steps/action_rules.py
+++ b/acceptance_tests/features/steps/action_rules.py
@@ -129,3 +129,8 @@ def check_for_event(context, event_type):
             return
 
     test_helper.fail(f"Case {context.first_case['id']} event_type {event_type} not logged")
+
+
+@step('set action rule of type "{action_type}"')
+def set_action_rule(context, action_type):
+    setup_treatment_code_classified_action_rule(context, action_type)

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -92,7 +92,8 @@ def new_address_reported_event(context, sender):
 def new_address_reported_event_with_source_case_id(context, sender):
     context.case_id = str(uuid.uuid4())
     context.collection_exercise_id = str(uuid.uuid4())
-    context.sourceCaseId = str(context.case_created_events[0]['payload']['collectionCase']['id'])
+    context.first_case = context.case_created_events[0]['payload']['collectionCase']
+    context.sourceCaseId = str(context.first_case['id'])
     message = json.dumps(
         {
             "event": {
@@ -369,6 +370,12 @@ def create_msg_sent_to_field(context):
     test_helper.assertEqual(context.fwmt_emitted_case_id, context.case_id)
     test_helper.assertEqual(context.addressType, "SPG")
     test_helper.assertEqual(context.field_action_cancel_message['surveyName'], "CENSUS")
+
+
+@step('the action_plan_id is the census action_plan_id')
+def use_census_action_plan_id(context):
+    # For tests where the action plan id needs hardcoding - for example where skeleton cases are used
+    context.action_plan_id = Config.CENSUS_ACTION_PLAN_ID
 
 
 def _field_work_create_callback(ch, method, _properties, body, context):

--- a/acceptance_tests/features/steps/print_file.py
+++ b/acceptance_tests/features/steps/print_file.py
@@ -141,7 +141,7 @@ def check_correct_unreceipted_files_on_sftp_server(context, pack_code):
 @step('skeleton cases do not appear in "{pack_code}" print files')
 def check_skeleton_case_not_in_print_file(context, pack_code):
     with SftpUtility() as sftp_utility:
-        _check_print_file_does_not_contain_case(context, context.test_start_local_datetime, sftp_utility, pack_code)
+        _check_print_file_does_not_contain_case_ref(context, context.test_start_local_datetime, sftp_utility, pack_code)
 
 
 @then('there is a correct "{pack_code}" manifest file for each csv file written')
@@ -203,14 +203,14 @@ def _validate_print_file_content(context, sftp_utility, start_of_test, expected_
 
 
 @retry(retry_on_exception=lambda e: isinstance(e, FileNotFoundError), wait_fixed=1000, stop_max_attempt_number=120)
-def _check_print_file_does_not_contain_case(context, start_of_test, sftp_utility, pack_code):
+def _check_print_file_does_not_contain_case_ref(context, start_of_test, sftp_utility, pack_code):
     logger.debug('Checking for files on SFTP server')
     context.expected_print_files = sftp_utility.get_all_files_after_time(start_of_test, pack_code, ".csv.gpg")
     actual_content_list = sftp_utility.get_files_content_as_list(context.expected_print_files, pack_code)
     if not actual_content_list:
         raise FileNotFoundError
-    actual_content_list.sort()
-    test_helper.assertNotIn(context.case_created_events[0]['payload']['collectionCase']['caseRef'], actual_content_list)
+    test_helper.assertFalse(any(
+        context.case_created_events[0]['payload']['collectionCase']['caseRef'] in row for row in actual_content_list))
 
 
 def _check_manifest_files_created(context, pack_code):

--- a/acceptance_tests/features/steps/print_file.py
+++ b/acceptance_tests/features/steps/print_file.py
@@ -138,6 +138,12 @@ def check_correct_unreceipted_files_on_sftp_server(context, pack_code):
     _check_print_files_have_all_the_expected_data(context, expected_csv_lines, pack_code)
 
 
+@step('skeleton cases do not appear in "{pack_code}" print files')
+def check_skeleton_case_not_in_print_file(context, pack_code):
+    with SftpUtility() as sftp_utility:
+        _check_print_file_does_not_contain_case(context, context.test_start_local_datetime, sftp_utility, pack_code)
+
+
 @then('there is a correct "{pack_code}" manifest file for each csv file written')
 def check_manifest_files(context, pack_code):
     logger.debug("checking manifest files exist for csv files")
@@ -194,6 +200,17 @@ def _validate_print_file_content(context, sftp_utility, start_of_test, expected_
     actual_content_list.sort()
     expected_csv_lines.sort()
     test_helper.assertEquals(actual_content_list, expected_csv_lines, 'Print file contents did not match expected')
+
+
+@retry(retry_on_exception=lambda e: isinstance(e, FileNotFoundError), wait_fixed=1000, stop_max_attempt_number=120)
+def _check_print_file_does_not_contain_case(context, start_of_test, sftp_utility, pack_code):
+    logger.debug('Checking for files on SFTP server')
+    context.expected_print_files = sftp_utility.get_all_files_after_time(start_of_test, pack_code, ".csv.gpg")
+    actual_content_list = sftp_utility.get_files_content_as_list(context.expected_print_files, pack_code)
+    if not actual_content_list:
+        raise FileNotFoundError
+    actual_content_list.sort()
+    test_helper.assertNotIn(context.case_created_events[0]['payload']['collectionCase']['caseRef'], actual_content_list)
 
 
 def _check_manifest_files_created(context, pack_code):

--- a/config.py
+++ b/config.py
@@ -107,3 +107,5 @@ class Config:
     DB_PORT = os.getenv('DB_PORT', '6432')
     DB_NAME = os.getenv('DB_NAME', 'postgres')
     DB_USESSL = os.getenv('DB_USESSL', '')
+
+    CENSUS_ACTION_PLAN_ID = os.getenv('ACTION_PLAN_ID', 'c4415287-0e37-447b-9c3d-1a011c9fa3db')


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We don't want skeleton cases to be included in action plans
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Test added to load a small sample and create a skeleton case from a new address event. An action plan is run and the results are checked to ensure the skeleton case is not present.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run with built [action scheduler branch of the same name](https://github.com/ONSdigital/census-rm-action-scheduler/pull/84).
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/ThiV27TP/741-exclude-skeleton-cases-from-action-plans-3
# Screenshots (if appropriate):