### PR TITLE
Fix AM1 7.1 new address HI telephone capture

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -87,12 +87,13 @@ Feature: Address updates
     And a fulfilment request event is logged
 
   Scenario: Individual Telephone capture for new skeleton case
-    Given a NEW_ADDRESS_REPORTED event is sent from "FIELD" without sourceCaseId
+    Given the action plan and collection exercises IDs are the hardcoded census values
+    And a NEW_ADDRESS_REPORTED event with address type "HH" is sent from "FIELD"
     And a case created event is emitted
-    When there is a request for individual telephone capture for the case with address type "SPG" and country "E"
+    When there is a request for a new HI case for telephone capture for the parent case with address type "HH" and country "E"
     Then a UAC and QID with questionnaire type "21" type are generated and returned
-    And a UAC updated event is emitted linking the new UAC and QID to the requested case
-    And a fulfilment request event is logged
+    And a new individual child case for telephone capture is emitted to RH and Action Scheduler
+    And a UAC updated event is emitted linking the new UAC and QID to the individual case
 
   Scenario: New address event received with sourceCaseId and sends Create to Field
     Given sample file "sample_1_english_SPG_estab.csv" is loaded successfully
@@ -101,7 +102,7 @@ Feature: Address updates
     And a CREATE action instruction is sent to field
 
   Scenario: Skeleton cases are excluded from action rules
-    Given the action_plan_id is the census action_plan_id
+    Given the action plan and collection exercises IDs are the hardcoded census values
     And sample file "sample_1_english_SPG_unit.csv" is loaded successfully
     And a NEW_ADDRESS_REPORTED event is sent from "FIELD" with sourceCaseId
     And a case created event is emitted

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -408,7 +408,8 @@ def create_msg_sent_to_field(context):
 
 @step('the action plan and collection exercises IDs are the hardcoded census values')
 def use_census_action_plan_id(context):
-    # For tests where the action plan id needs hardcoding - for example where skeleton cases are used
+    # For tests where the action plan and collection exercise ID need hardcoding
+    # e.g where skeleton cases are used
     context.action_plan_id = Config.CENSUS_ACTION_PLAN_ID
     context.collection_exercise_id = Config.CENSUS_COLLECTION_EXERCISE_ID
 

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -173,8 +173,9 @@ def new_address_reported_event_with_minimal_fields(context, sender):
             content_type='application/json',
             routing_key=Config.RABBITMQ_ADDRESS_ROUTING_KEY)
 
+
 @step('a NEW_ADDRESS_REPORTED event with address type "{address_type}" is sent from "{sender}"')
-def new_address_reported_event_with_minimal_fields(context, address_type, sender):
+def new_address_reported_event_for_address_type(context, address_type, sender):
     context.case_id = str(uuid.uuid4())
     message = json.dumps(
         {
@@ -205,6 +206,7 @@ def new_address_reported_event_with_minimal_fields(context, address_type, sender
             message=message,
             content_type='application/json',
             routing_key=Config.RABBITMQ_ADDRESS_ROUTING_KEY)
+
 
 @step('the case can be retrieved')
 def retrieve_skeleton_case(context):

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -173,6 +173,38 @@ def new_address_reported_event_with_minimal_fields(context, sender):
             content_type='application/json',
             routing_key=Config.RABBITMQ_ADDRESS_ROUTING_KEY)
 
+@step('a NEW_ADDRESS_REPORTED event with address type "{address_type}" is sent from "{sender}"')
+def new_address_reported_event_with_minimal_fields(context, address_type, sender):
+    context.case_id = str(uuid.uuid4())
+    message = json.dumps(
+        {
+            "event": {
+                "type": "NEW_ADDRESS_REPORTED",
+                "source": "FIELDWORK_GATEWAY",
+                "channel": sender,
+                "dateTime": "2011-08-12T20:17:46.384Z",
+                "transactionId": "d9126d67-2830-4aac-8e52-47fb8f84d3b9"
+            },
+            "payload": {
+                "newAddress": {
+                    "collectionCase": {
+                        "id": context.case_id,
+                        "caseType": address_type,
+                        "address": {
+                            "region": "E00001234",
+                            "addressType": address_type,
+                            "addressLevel": "U"
+                        }
+                    }
+                }
+            }
+        }
+    )
+    with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
+        rabbit.publish_message(
+            message=message,
+            content_type='application/json',
+            routing_key=Config.RABBITMQ_ADDRESS_ROUTING_KEY)
 
 @step('the case can be retrieved')
 def retrieve_skeleton_case(context):
@@ -372,10 +404,11 @@ def create_msg_sent_to_field(context):
     test_helper.assertEqual(context.field_action_cancel_message['surveyName'], "CENSUS")
 
 
-@step('the action_plan_id is the census action_plan_id')
+@step('the action plan and collection exercises IDs are the hardcoded census values')
 def use_census_action_plan_id(context):
     # For tests where the action plan id needs hardcoding - for example where skeleton cases are used
     context.action_plan_id = Config.CENSUS_ACTION_PLAN_ID
+    context.collection_exercise_id = Config.CENSUS_COLLECTION_EXERCISE_ID
 
 
 def _field_work_create_callback(ch, method, _properties, body, context):

--- a/config.py
+++ b/config.py
@@ -109,3 +109,4 @@ class Config:
     DB_USESSL = os.getenv('DB_USESSL', '')
 
     CENSUS_ACTION_PLAN_ID = os.getenv('ACTION_PLAN_ID', 'c4415287-0e37-447b-9c3d-1a011c9fa3db')
+    CENSUS_COLLECTION_EXERCISE_ID = os.getenv('COLLECTION_EXERCISE_ID', '34d7f3bb-91c9-45d0-bb2d-90afce4fc790')


### PR DESCRIPTION
# Motivation and Context
The test in #249 was not testing the correct scenario, it should be testing a HI telephone capture request against an HH case.

# What has changed
* Fix test
* Add hardcoded census collection exercise ID

# How to test?
Run the AT's

# Links
https://trello.com/c/fcAwwVuo/957-fix-skeleton-individual-hi-telephone-capture-acceptance-test