### PR TITLE
Capture callId on refusals

### DIFF
--- a/acceptance_tests/features/steps/refusal.py
+++ b/acceptance_tests/features/steps/refusal.py
@@ -31,6 +31,7 @@ def _send_refusal_msg_to_rabbit(case_id, refusal_type):
                     "type": refusal_type,
                     "report": "Test refusal",
                     "agentId": None,
+                    "callId": "8f04b136-d13c-4d88-9068-331560a26bec",
                     "collectionCase": {
                         "id": case_id
                     },


### PR DESCRIPTION
# Motivation and Context
We want to be able to capture a callId sent from CC/Field on refusals because reasons.

# What has changed
Added the callId to the DTO.

# How to test?
Send in a refusal including a callId. Check the event table to make sure it got persisted.

# Links
Trello: https://trello.com/c/ZwNBjX2s