### PR TITLE
HI individual PQ link for HH cases without individual case ID

### DIFF
--- a/acceptance_tests/features/blank_questionnaire.feature
+++ b/acceptance_tests/features/blank_questionnaire.feature
@@ -125,7 +125,7 @@ Feature: Handling Blank Questionnaire Scenario
   Scenario Outline: Blank questionnaire against an unlinked qid
     Given sample file "<sample file>" is loaded successfully
     And if required, a new qid and case are created for case type "<case type>" address level "<address level>" qid type "<qid type>" and country "<country>"
-    And an unaddressed message of questionnaire type <form type> is sent
+    And an unaddressed QID request message of questionnaire type <form type> is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     And the offline receipt msg for the receipted case is put on the GCP pubsub for an unlinked qid
     And a blank questionnaire receipts comes in for an unlinked qid

--- a/acceptance_tests/features/ccs_property_listed.feature
+++ b/acceptance_tests/features/ccs_property_listed.feature
@@ -9,7 +9,7 @@ Feature: Handle CCS (Census Coverage Survey) Property Listed events
 
   @smoke
   Scenario: Log event when a CCS Property Listed event is received with a qid
-    When an unaddressed message of questionnaire type 71 is sent
+    When an unaddressed QID request message of questionnaire type 71 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     When a CCS Property Listed event is sent with a qid
     And the CCS Property Listed case is created with address type "HH"

--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -32,7 +32,7 @@ Feature: Case processor handles receipt message from pubsub service
     And the events logged for the receipted case are [SAMPLE_LOADED,RESPONSE_RECEIVED]
 
   Scenario: Receipt of unaddressed continuation questionnaire does not send to Field
-    Given an unaddressed message of questionnaire type 63 is sent
+    Given an unaddressed QID request message of questionnaire type 63 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     And a CCS Property Listed event is sent with a qid
     And the CCS Property Listed case is created with address type "HH"

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -56,7 +56,7 @@ def send_individual_linked_message_and_verify_new_case(context):
 
 
 @step("an Individual Questionnaire Linked message with no individual case ID is sent and ingested")
-def send_individual_linked_message_and_verify_new_case(context):
+def send_individual_linked_message_without_individual_case_id_and_verify_new_case(context):
     send_questionnaire_link_for_individual_hh_case(context, include_individual_id=False)
     context.linked_case_id = context.individual_case_id = get_case_id_by_questionnaire_id(
         context.expected_questionnaire_id)

--- a/acceptance_tests/features/unaddressed.feature
+++ b/acceptance_tests/features/unaddressed.feature
@@ -1,46 +1,54 @@
 Feature: Generating UAC/QID pairs for unaddressed letters & questionnaires
 
   Scenario: UAC/QID pair generated for unaddressed
-    When an unaddressed message of questionnaire type 01 is sent
+    When an unaddressed QID request message of questionnaire type 01 is sent
     Then a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
 
   Scenario: Questionnaire linked to unaddressed
     Given sample file "sample_for_questionnaire_linked.csv" is loaded successfully
-    When an unaddressed message of questionnaire type 01 is sent
+    When an unaddressed QID request message of questionnaire type 01 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
-    Then a Questionnaire Linked message is sent
-    And a Questionnaire Linked event is logged
+    And a Questionnaire Linked message is sent
+    Then a Questionnaire Linked event is logged
 
   Scenario: Questionnaire linked to unaddressed CCS case
     Given a CCS Property Listed event is sent
     And the CCS Property Listed case is created with address type "HH"
-    When an unaddressed message of questionnaire type 01 is sent
+    When an unaddressed QID request message of questionnaire type 01 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
-    Then a Questionnaire Linked message is sent for the CCS case
-    And a Questionnaire Linked event is logged
+    And a Questionnaire Linked message is sent for the CCS case
+    Then a Questionnaire Linked event is logged
 
   Scenario: Individual Questionnaire linked to unaddressed
     Given sample file "sample_for_questionnaire_linked.csv" is loaded successfully
-    When an unaddressed message of questionnaire type 21 is sent
+    When an unaddressed QID request message of questionnaire type 21 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
-    Then an Individual Questionnaire Linked message is sent
-    And a Questionnaire Linked event is logged
+    And an Individual Questionnaire Linked message is sent and ingested
+    Then a Questionnaire Linked event is logged
+    And the HI individual case can be retrieved
+
+  Scenario: Individual Questionnaire linked to unaddressed without specifying individual case ID
+    Given sample file "sample_for_questionnaire_linked.csv" is loaded successfully
+    When an unaddressed QID request message of questionnaire type 21 is sent
+    And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
+    And an Individual Questionnaire Linked message with no individual case ID is sent and ingested
+    Then a Questionnaire Linked event is logged
     And the HI individual case can be retrieved
 
   Scenario: Receipt of unlinked unaddressed
-    When an unaddressed message of questionnaire type 01 is sent
-    Then a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
+    When an unaddressed QID request message of questionnaire type 01 is sent
+    And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     And a receipt for the unlinked UAC-QID pair is received
-    And message redelivery does not go bananas
+    Then message redelivery does not go bananas
 
   Scenario: Unlinked QID is relinked to new case
     Given sample file "sample_for_questionnaire_linked.csv" is loaded successfully
-    When an unaddressed message of questionnaire type 01 is sent
+    When an unaddressed QID request message of questionnaire type 01 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
-    Then a Questionnaire Linked message is sent
+    And a Questionnaire Linked message is sent
     And a Questionnaire Linked event is logged
     And a Questionnaire Linked message is sent to relink to a new case
-    And a Questionnaire Linked event is logged
+    Then a Questionnaire Linked event is logged
     And a Questionnaire Unlinked event is logged
 
   @smoke

--- a/acceptance_tests/features/unaddressed.feature
+++ b/acceptance_tests/features/unaddressed.feature
@@ -36,9 +36,9 @@ Feature: Generating UAC/QID pairs for unaddressed letters & questionnaires
     And the HI individual case can be retrieved
 
   Scenario: Receipt of unlinked unaddressed
-    When an unaddressed QID request message of questionnaire type 01 is sent
+    Given an unaddressed QID request message of questionnaire type 01 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
-    And a receipt for the unlinked UAC-QID pair is received
+    When a receipt for the unlinked UAC-QID pair is received
     Then message redelivery does not go bananas
 
   Scenario: Unlinked QID is relinked to new case


### PR DESCRIPTION
# Motivation and Context
Some services need to be able to spawn HI child cases on PQ links without specifying an individual case ID, we can just generate a new random ID.

# What has changed
* Add test for HH individual PQ link with no individual case ID

# How to test?
Build and run linked branch, run AT's

# Links
https://trello.com/c/6peilnCZ/988-change-for-hi-case-from-pq-link-5