### PR TITLE
Revert workload identity

### DIFF
--- a/acceptance_tests_pod.yml
+++ b/acceptance_tests_pod.yml
@@ -6,7 +6,6 @@ metadata:
     app: acceptance-tests
     env: dev
 spec:
-  serviceAccountName: acceptance-tests
   securityContext:
     fsGroup: 1000
   containers:
@@ -38,6 +37,8 @@ spec:
       readOnly: true
     - name: sftp-keys
       mountPath: "/home/acceptancetests/.sftp-ssh"
+    - name: gcp-credentials
+      mountPath: "/home/acceptancetests/gcp-credentials"
     env:
     - name: DB_USERNAME
       valueFrom:
@@ -79,6 +80,11 @@ spec:
         configMapKeyRef:
           key: sftp-qm-supplier-directory
           name: project-config
+    - name: SENT_PRINT_FILE_BUCKET
+      valueFrom:
+        configMapKeyRef:
+          key: sent-print-file-bucket
+          name: project-config
     - name: SFTP_HOST
       valueFrom:
         secretKeyRef:
@@ -108,6 +114,13 @@ spec:
       value: "notify-stub"
     - name: NOTIFY_STUB_PORT
       value: "80"
+    - name: GOOGLE_SERVICE_ACCOUNT_JSON
+      valueFrom:
+        secretKeyRef:
+          name: pubsub-credentials
+          key: service-account-key.json
+    - name: GOOGLE_APPLICATION_CREDENTIALS
+      value: "/home/acceptancetests/gcp-credentials/service-account-key.json"
     - name: SENT_PRINT_FILE_BUCKET
       valueFrom:
         configMapKeyRef:
@@ -137,6 +150,8 @@ spec:
       value: "case-api"
     - name: CASEAPI_SERVICE_PORT
       value: "80"
+    - name: SFTP_PORT
+      value: "22"
     - name: RECEIPT_TOPIC_ID
       valueFrom:
         configMapKeyRef:
@@ -185,6 +200,9 @@ spec:
         path: "postgresql.crt"
       - key: "postgresql.key"
         path: "postgresql.key"
+  - name: gcp-credentials
+    secret:
+      secretName: pubsub-credentials
   - name: sftp-keys
     secret:
       secretName: sftp-ssh-credentials

--- a/config.py
+++ b/config.py
@@ -69,6 +69,9 @@ class Config:
     FULFILMENT_CONFIRMED_TOPIC_ID = os.getenv("FULFILMENT_CONFIRMED_TOPIC",
                                               "fulfilment-topic")
 
+    GOOGLE_APPLICATION_CREDENTIALS = os.getenv('GOOGLE_APPLICATION_CREDENTIALS')
+    GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv('GOOGLE_SERVICE_ACCOUNT_JSON')
+
     RABBITMQ_INBOUND_REFUSAL_QUEUE = 'case.refusals'
     RABBITMQ_INBOUND_FULFILMENT_REQUEST_QUEUE = 'case.fulfilments'
     RABBITMQ_INBOUND_NOTIFY_FULFILMENT_REQUEST_QUEUE = 'notify.fulfilments'


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
After enabling Workload Identity in our cluster, we're unable to connect to the read replica SQL instance with our census-rm-toolbox. To buy us some time to investigate, we can revert these changes for now.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Reverted

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Z5kmTtll/970-workload-identity-update-pub-sub-printfilesvc-acceptance-and-performance-tests-13