### PR TITLE
Check individual case id is not used when linking to CE parent case

### DIFF
--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -157,5 +157,5 @@ def ccs_case_event_logged(context):
 
 @step("the CCS Case created is set against the correct qid")
 def check_created_uacqid_link_has_new_ccs_against_it(context):
-    linked_ccs_case_id = get_case_id_by_questionnaire_id(context.expected_questionnaire_id)
+    linked_ccs_case_id = get_case_id_by_questionnaire_id(context)
     test_helper.assertEqual(linked_ccs_case_id, context.case_id)

--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -157,5 +157,5 @@ def ccs_case_event_logged(context):
 
 @step("the CCS Case created is set against the correct qid")
 def check_created_uacqid_link_has_new_ccs_against_it(context):
-    linked_ccs_case_id = get_case_id_by_questionnaire_id(context)
+    linked_ccs_case_id = get_case_id_by_questionnaire_id(context.expected_questionnaire_id)
     test_helper.assertEqual(linked_ccs_case_id, context.case_id)

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -52,14 +52,13 @@ def send_linked_message_for_blank_questionnaire(context):
 @step("an Individual Questionnaire Linked message is sent and ingested")
 def send_individual_linked_message_and_verify_new_case(context):
     context.linked_case_id = send_questionnaire_link_for_individual_hh_case(context)
-    get_case_id_by_questionnaire_id(context.expected_questionnaire_id)
+    get_case_id_by_questionnaire_id(context)
 
 
 @step("an Individual Questionnaire Linked message with no individual case ID is sent and ingested")
 def send_individual_linked_message_without_individual_case_id_and_verify_new_case(context):
     send_questionnaire_link_for_individual_hh_case(context, include_individual_id=False)
-    context.linked_case_id = context.individual_case_id = get_case_id_by_questionnaire_id(
-        context.expected_questionnaire_id)
+    context.linked_case_id = context.individual_case_id = get_case_id_by_questionnaire_id(context)
 
 
 @step("a Questionnaire Linked message is sent for the CCS case")
@@ -112,7 +111,12 @@ def check_uac_message_is_received(context):
 
 @step("a Questionnaire Linked event is logged")
 def check_questionnaire_linked_logging(context):
-    check_question_linked_event_is_logged(context)
+    check_question_linked_event_is_logged(context.linked_case_id)
+
+
+@step("a Questionnaire Linked event on the parent case is logged")
+def check_questionnaire_linked_logging_on_parent(context):
+    check_question_linked_event_is_logged(context.parent_case_id)
 
 
 @step("a Questionnaire Unlinked event is logged")
@@ -122,8 +126,7 @@ def check_questionnaire_unlinked_logging(context):
 
 
 @retry(stop_max_attempt_number=10, wait_fixed=1000)
-def check_question_linked_event_is_logged(context):
-    case_id = context.linked_case_id
+def check_question_linked_event_is_logged(case_id):
     response = requests.get(f'{caseapi_url}{case_id}', params={'caseEvents': True})
     response_json = response.json()
     for case_event in response_json['caseEvents']:
@@ -145,10 +148,11 @@ def check_question_unlinked_event_is_logged(context):
 
 
 @retry(stop_max_attempt_number=10, wait_fixed=1000)
-def get_case_id_by_questionnaire_id(questionnaire_id):
-    response = requests.get(f'{caseapi_url}/qid/{questionnaire_id}')
+def get_case_id_by_questionnaire_id(context):
+    response = requests.get(f'{caseapi_url}/qid/{context.expected_questionnaire_id}')
     test_helper.assertEqual(response.status_code, 200, "Unexpected status code")
     response_json = response.json()
+    context.parent_case_id = response_json['id']
     return response_json['id']
 
 

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -52,13 +52,14 @@ def send_linked_message_for_blank_questionnaire(context):
 @step("an Individual Questionnaire Linked message is sent and ingested")
 def send_individual_linked_message_and_verify_new_case(context):
     context.linked_case_id = send_questionnaire_link_for_individual_hh_case(context)
-    get_case_id_by_questionnaire_id(context)
+    get_case_id_by_questionnaire_id(context.expected_questionnaire_id)
 
 
 @step("an Individual Questionnaire Linked message with no individual case ID is sent and ingested")
 def send_individual_linked_message_without_individual_case_id_and_verify_new_case(context):
     send_questionnaire_link_for_individual_hh_case(context, include_individual_id=False)
-    context.linked_case_id = context.individual_case_id = get_case_id_by_questionnaire_id(context)
+    context.linked_case_id = context.individual_case_id = get_case_id_by_questionnaire_id(
+        context.expected_questionnaire_id)
 
 
 @step("a Questionnaire Linked message is sent for the CCS case")
@@ -116,7 +117,7 @@ def check_questionnaire_linked_logging(context):
 
 @step("a Questionnaire Linked event on the parent case is logged")
 def check_questionnaire_linked_logging_on_parent(context):
-    check_question_linked_event_is_logged(context.parent_case_id)
+    check_question_linked_event_is_logged(context.linked_case['id'])
 
 
 @step("a Questionnaire Unlinked event is logged")
@@ -148,11 +149,10 @@ def check_question_unlinked_event_is_logged(context):
 
 
 @retry(stop_max_attempt_number=10, wait_fixed=1000)
-def get_case_id_by_questionnaire_id(context):
-    response = requests.get(f'{caseapi_url}/qid/{context.expected_questionnaire_id}')
+def get_case_id_by_questionnaire_id(questionnaire_id):
+    response = requests.get(f'{caseapi_url}/qid/{questionnaire_id}')
     test_helper.assertEqual(response.status_code, 200, "Unexpected status code")
     response_json = response.json()
-    context.parent_case_id = response_json['id']
     return response_json['id']
 
 

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -224,6 +224,12 @@ def retrieve_hi_case(context):
     test_helper.assertEqual(response.status_code, 200, 'Case not found')
 
 
+@step('no case using the individual case id is created')
+def check_case_does_not_exist(context):
+    response = requests.get(f'{caseapi_url}{context.linked_case_id}')
+    test_helper.assertEqual(response.status_code, 404, 'Case should not have been created')
+
+
 def _send_questionnaire_linked_msg_to_rabbit(questionnaire_id, case_id):
     questionnaire_linked_message = {
         'event': {

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -228,12 +228,6 @@ def retrieve_hi_case(context):
     test_helper.assertEqual(response.status_code, 200, 'Case not found')
 
 
-@step('no case using the individual case id is created')
-def check_case_does_not_exist(context):
-    response = requests.get(f'{caseapi_url}{context.linked_case_id}')
-    test_helper.assertEqual(response.status_code, 404, 'Case should not have been created')
-
-
 def _send_questionnaire_linked_msg_to_rabbit(questionnaire_id, case_id):
     questionnaire_linked_message = {
         'event': {

--- a/acceptance_tests/features/unaddressed.feature
+++ b/acceptance_tests/features/unaddressed.feature
@@ -35,6 +35,13 @@ Feature: Generating UAC/QID pairs for unaddressed letters & questionnaires
     Then a Questionnaire Linked event is logged
     And the HI individual case can be retrieved
 
+  Scenario: A Questionnaire linked event ignores the IndividualCaseId if linking to a CE case
+    Given sample file "sample_3_welsh_CE_estab.csv" is loaded successfully
+    When an unaddressed QID request message of questionnaire type 21 is sent
+    And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
+    And an Individual Questionnaire Linked message is sent and ingested
+    Then no case using the individual case id is created
+
   Scenario: Receipt of unlinked unaddressed
     Given an unaddressed QID request message of questionnaire type 01 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler

--- a/acceptance_tests/features/unaddressed.feature
+++ b/acceptance_tests/features/unaddressed.feature
@@ -40,7 +40,7 @@ Feature: Generating UAC/QID pairs for unaddressed letters & questionnaires
     When an unaddressed QID request message of questionnaire type 21 is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     And an Individual Questionnaire Linked message is sent and ingested
-    Then no case using the individual case id is created
+    Then a Questionnaire Linked event on the parent case is logged
 
   Scenario: Receipt of unlinked unaddressed
     Given an unaddressed QID request message of questionnaire type 01 is sent


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Currently if a questionnaire linked event comes in with an individual case id present and the parent case is CE/SPG, it'll chuck an error. We now want to link the questionnaire to the parent case and ignore the individual case id.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Test added to test this
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run acceptance test with case-processor built on [branch of the same name](https://github.com/ONSdigital/census-rm-case-processor/pull/163).
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/V7O2qqSV/1017-pq-link-ignore-individual-case-id-if-parent-case-is-not-hh-5
# Screenshots (if appropriate):