### PR TITLE
RMC-233 Request IR via EQ

### DIFF
--- a/acceptance_tests/features/eq_individual_response.feature
+++ b/acceptance_tests/features/eq_individual_response.feature
@@ -1,0 +1,40 @@
+Feature: Request individual response via EQ
+
+  Scenario Outline: Individual UAC SMS requests via EQ
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    When an individual SMS UAC fulfilment request "<fulfilment code>" message is sent by EQ
+    Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
+    And notify api was called with template id "<template ID>"
+    And a UAC updated message with "<questionnaire type>" questionnaire type is emitted for the individual case
+    And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
+    And the individual case has these events logged [RM_UAC_CREATED]
+
+    Examples: Household UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | template ID                          |
+      | UACIT1          | 21                 | 21447bc2-e7c7-41ba-8c5e-7a5893068525 |
+
+    @regression
+    Examples: Household UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | template ID                          |
+      | UACIT2          | 22                 | 23f96daf-9674-4087-acfc-ffe98a52cf16 |
+      # TODO UACIT2W should be type 23
+      | UACIT2W         | 22                 | ef045f43-ffa8-4047-b8e2-65bfbce0f026 |
+      | UACIT4          | 24                 | 1ccd02a4-9b90-4234-ab7a-9215cb498f14 |
+
+  Scenario Outline: Individual UAC print requests via EQ
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    When an individual print UAC fulfilment request "<fulfilment code>" message is sent by EQ
+    Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
+    And correctly formatted individual response questionnaires are created for "<fulfilment code>" with questionnaire type "<questionnaire type>"
+    And the fulfilment request event is logged
+
+    Examples: Individual Response Questionnaires fulfilment codes
+      | fulfilment code | questionnaire type |
+      | P_OR_I1         | 21                 |
+
+    @regression
+    Examples: Individual Response Questionnaires fulfilment codes
+      | fulfilment code | questionnaire type |
+      | P_OR_I2         | 22                 |
+      | P_OR_I2W        | 23                 |
+      | P_OR_I4         | 24                 |

--- a/acceptance_tests/features/eq_individual_response.feature
+++ b/acceptance_tests/features/eq_individual_response.feature
@@ -4,22 +4,21 @@ Feature: Request individual response via EQ
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When an individual SMS UAC fulfilment request "<fulfilment code>" message is sent by EQ
     Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
-    And notify api was called with template id "<template ID>"
+    And notify api was called with SMS template "<SMS template>"
     And a UAC updated message with "<questionnaire type>" questionnaire type is emitted for the individual case
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
     And the individual case has these events logged [RM_UAC_CREATED]
 
-    Examples: Household UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | template ID                          |
-      | UACIT1          | 21                 | 21447bc2-e7c7-41ba-8c5e-7a5893068525 |
+    Examples: Individual UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | SMS template       |
+      | UACIT1          | 21                 | individual English |
 
     @regression
-    Examples: Household UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | template ID                          |
-      | UACIT2          | 22                 | 23f96daf-9674-4087-acfc-ffe98a52cf16 |
-      # TODO UACIT2W should be type 23
-      | UACIT2W         | 22                 | ef045f43-ffa8-4047-b8e2-65bfbce0f026 |
-      | UACIT4          | 24                 | 1ccd02a4-9b90-4234-ab7a-9215cb498f14 |
+    Examples: Individual UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | SMS template                 |
+      | UACIT2          | 22                 | individual Welsh and English |
+      | UACIT2W         | 23                 | individual Welsh             |
+      | UACIT4          | 24                 | individual Northern Ireland  |
 
   Scenario Outline: Individual UAC print requests via EQ
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -65,12 +65,12 @@ Feature: Handle fulfilment request events
     And correctly formatted on request contn questionnaire print and manifest files for "<fulfilment code>" are created
     And the questionnaire fulfilment case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED,PRINT_CASE_SELECTED]
 
-    Examples: Continuation Questionnaires
+    Examples: Continuation Questionnaires: <fulfilment code>
       | fulfilment code | questionnaire type |
       | P_OR_HC1        | 11                 |
 
     @regression
-    Examples: Continuation Questionnaires
+    Examples: Continuation Questionnaires: <fulfilment code>
       | fulfilment code | questionnaire type |
       | P_OR_HC2        | 12                 |
       | P_OR_HC2W       | 13                 |
@@ -84,12 +84,12 @@ Feature: Handle fulfilment request events
     And correctly formatted on request HH UAC supplementary material print and manifest files for "<fulfilment code>" are created
     And the fulfilment request event is logged
 
-    Examples: UAC Questionnaires
+    Examples: UAC Questionnaires: <fulfilment code>
       | fulfilment code | questionnaire type |
       | P_UAC_UACHHP1   | 01                 |
 
     @regression
-    Examples: UAC Questionnaires
+    Examples: UAC Questionnaires: <fulfilment code>
       | fulfilment code | questionnaire type |
       | P_UAC_UACHHP2B  | 02                 |
       | P_UAC_UACHHP4   | 04                 |
@@ -220,12 +220,12 @@ Feature: Handle fulfilment request events
     And correctly formatted individual response questionnaires are created for "<fulfilment code>" with questionnaire type "<questionnaire type>"
     And the fulfilment request event is logged
 
-    Examples: Individual Response Questionnaires fulfilment codes
+    Examples: Individual Response Questionnaires fulfilment codes: <fulfilment code>
       | fulfilment code | questionnaire type |
       | P_OR_I1         | 21                 |
 
     @regression
-    Examples: Individual Response Questionnaires fulfilment codes
+    Examples: Individual Response Questionnaires fulfilment codes: <fulfilment code>
       | fulfilment code | questionnaire type |
       | P_OR_I2         | 22                 |
       | P_OR_I2W        | 23                 |
@@ -239,12 +239,12 @@ Feature: Handle fulfilment request events
     And correctly formatted individual UAC print responses are created for "<fulfilment code>" with questionnaire type "<questionnaire type>"
     And the fulfilment request event is logged
 
-    Examples: Individual UAC Response fulfilment codes
+    Examples: Individual UAC Response fulfilment codes: <fulfilment code>
       | fulfilment code | questionnaire type |
       | P_UAC_UACIP1    | 21                 |
 
     @regression
-    Examples: Individual UAC Response fulfilment codes
+    Examples: Individual UAC Response fulfilment codes: <fulfilment code>
       | fulfilment code | questionnaire type |
       | P_UAC_UACIP2B   | 22                 |
       | P_UAC_UACIP4    | 24                 |

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -39,18 +39,8 @@ Feature: Handle fulfilment request events
       | UACIT2W         | 23                 | individual Welsh             |
       | UACIT4          | 24                 | individual Northern Ireland  |
 
-  Scenario: Individual Response Fulfilment is received Log event without contact details, save new case, emit new case
-    Given sample file "sample_input_england_census_spec.csv" is loaded
-    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
-    When a UAC fulfilment request "UACIT1" message for a created case is sent
-    Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
-    And notify api was called with SMS template "individual English"
-    And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
-    And the individual case has these events logged [RM_UAC_CREATED]
-
   Scenario Outline: Generate print files and log events for questionnaire fulfilment requests
-    Given sample file "sample_1_english_HH_unit.csv" is loaded
-    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When a PQ fulfilment request event with fulfilment code "<fulfilment code>" is received by RM
     Then a UAC updated message with "<questionnaire type>" questionnaire type is emitted
     And correctly formatted on request questionnaire print and manifest files for "<fulfilment code>" are created
@@ -64,14 +54,12 @@ Feature: Handle fulfilment request events
     @regression
     Examples: Questionnaire: <fulfilment code>
       | fulfilment code | questionnaire type |
-      | P_OR_H1         | 01                 |
       | P_OR_H2         | 02                 |
       | P_OR_H2W        | 03                 |
       | P_OR_H4         | 04                 |
 
   Scenario Outline: Generate print files and log events for continuation questionnaire fulfilment requests
-    Given sample file "sample_1_english_HH_unit.csv" is loaded
-    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When a PQ continuation fulfilment request event with fulfilment code "<fulfilment code>" is received by RM
     Then a UAC updated message with "<questionnaire type>" questionnaire type is emitted
     And correctly formatted on request contn questionnaire print and manifest files for "<fulfilment code>" are created
@@ -90,8 +78,7 @@ Feature: Handle fulfilment request events
 
 
   Scenario Outline: Generate print files and log events for Household UAC print fulfilment letter requests
-    Given sample file "sample_1_english_HH_unit.csv" is loaded
-    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When a HH print UAC fulfilment request "<fulfilment code>" message for a created case is sent
     Then a UAC updated message with "<questionnaire type>" questionnaire type is emitted
     And correctly formatted on request HH UAC supplementary material print and manifest files for "<fulfilment code>" are created
@@ -227,42 +214,40 @@ Feature: Handle fulfilment request events
       | P_ER_ILER2B     |
 
   Scenario Outline: Generate print files and log events for individual questionnaire fulfilment requests
-    Given sample file "sample_1_english_HH_unit.csv" is loaded
-    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When an individual print fulfilment request "<fulfilment code>" is received by RM
     Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
-    And correctly formatted individual response questionnaires are are created with "<fulfilment code>"
+    And correctly formatted individual response questionnaires are created for "<fulfilment code>" with questionnaire type "<questionnaire type>"
     And the fulfilment request event is logged
 
     Examples: Individual Response Questionnaires fulfilment codes
-      | fulfilment code |
-      | P_OR_I1         |
+      | fulfilment code | questionnaire type |
+      | P_OR_I1         | 21                 |
 
     @regression
     Examples: Individual Response Questionnaires fulfilment codes
-      | fulfilment code |
-      | P_OR_I2         |
-      | P_OR_I2W        |
-      | P_OR_I4         |
+      | fulfilment code | questionnaire type |
+      | P_OR_I2         | 22                 |
+      | P_OR_I2W        | 23                 |
+      | P_OR_I4         | 24                 |
 
 
   Scenario Outline: Generate print files and log events for individual UAC print fulfilment letter requests
-    Given sample file "sample_1_english_HH_unit.csv" is loaded
-    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When an individual print fulfilment request "<fulfilment code>" is received by RM
     Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
-    And correctly formatted individual UAC print responses are created with "<fulfilment code>"
+    And correctly formatted individual UAC print responses are created for "<fulfilment code>" with questionnaire type "<questionnaire type>"
     And the fulfilment request event is logged
 
     Examples: Individual UAC Response fulfilment codes
-      | fulfilment code |
-      | P_UAC_UACIP1    |
+      | fulfilment code | questionnaire type |
+      | P_UAC_UACIP1    | 21                 |
 
     @regression
     Examples: Individual UAC Response fulfilment codes
-      | fulfilment code |
-      | P_UAC_UACIP2B   |
-      | P_UAC_UACIP4    |
+      | fulfilment code | questionnaire type |
+      | P_UAC_UACIP2B   | 22                 |
+      | P_UAC_UACIP4    | 24                 |
 
   Scenario: Generate individual cases and check that no actions rules are triggered for them
     Given sample file "sample_individual_case_spec.csv" is loaded successfully
@@ -284,13 +269,11 @@ Feature: Handle fulfilment request events
       | P_OR_H1         | 01                 |
 
   Scenario: Fulfilment is confirmed by QM
-    Given sample file "sample_1_english_HH_unit.csv" is loaded
-    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When QM sends a fulfilment confirmed message via pubsub
     Then the questionnaire fulfilment case has these events logged [SAMPLE_LOADED,FULFILMENT_CONFIRMED]
 
   Scenario: Fulfilment is confirmed by PPO
-    Given sample file "sample_1_english_HH_unit.csv" is loaded
-    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When PPO sends a fulfilment confirmed message via pubsub
     Then the questionnaire fulfilment case has these events logged [SAMPLE_LOADED,FULFILMENT_CONFIRMED]

--- a/acceptance_tests/features/steps/eq_fulfilment.py
+++ b/acceptance_tests/features/steps/eq_fulfilment.py
@@ -1,0 +1,72 @@
+import json
+import uuid
+
+import requests
+from behave import step
+
+from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
+from config import Config
+
+
+@step('an individual SMS UAC fulfilment request "{fulfilment_code}" message is sent by EQ')
+def send_eq_sms_fulfilment_message(context, fulfilment_code):
+    requests.get(f'{Config.NOTIFY_STUB_SERVICE}/reset')
+
+    context.fulfilment_requested_case_id = context.uac_created_events[0]['payload']['uac']['caseId']
+    context.individual_case_id = str(uuid.uuid4())
+    message = json.dumps(
+        {
+            "event": {
+                "type": "FULFILMENT_REQUESTED",
+                "source": "QUESTIONNAIRE_RUNNER",
+                "channel": "EQ",
+                "dateTime": "2019-07-07T22:37:11.988Z",
+                "transactionId": "d2541acb-230a-4ade-8123-eee2310c9143"
+            },
+            "payload": {
+                "fulfilmentRequest": {
+                    "fulfilmentCode": fulfilment_code,
+                    "caseId": context.fulfilment_requested_case_id,
+                    "individualCaseId": context.individual_case_id,
+                    "contact": {
+                        "telNo": "01234567",
+                    }
+                }
+            }
+        }
+    )
+
+    publish_to_pubsub(message, Config.EQ_FULFILMENT_PROJECT_ID, Config.EQ_FULFILMENT_TOPIC_ID)
+
+
+@step('an individual print UAC fulfilment request "{fulfilment_code}" message is sent by EQ')
+def send_eq_print_fulfilment_message(context, fulfilment_code):
+    requests.get(f'{Config.NOTIFY_STUB_SERVICE}/reset')
+
+    context.fulfilment_requested_case_id = context.uac_created_events[0]['payload']['uac']['caseId']
+    context.individual_case_id = str(uuid.uuid4())
+    message = json.dumps(
+        {
+            "event": {
+                "type": "FULFILMENT_REQUESTED",
+                "source": "QUESTIONNAIRE_RUNNER",
+                "channel": "EQ",
+                "dateTime": "2019-07-07T22:37:11.988Z",
+                "transactionId": "d2541acb-230a-4ade-8123-eee2310c9143"
+            },
+            "payload": {
+                "fulfilmentRequest": {
+                    "fulfilmentCode": fulfilment_code,
+                    "caseId": context.fulfilment_requested_case_id,
+                    "individualCaseId": context.individual_case_id,
+                    "contact": {
+                        "title": "Ms",
+                        "forename": "jo",
+                        "surname": "smith",
+                    },
+                }
+            }
+        }
+    )
+
+    publish_to_pubsub(message, Config.EQ_FULFILMENT_PROJECT_ID, Config.EQ_FULFILMENT_TOPIC_ID)

--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -4,7 +4,6 @@ import uuid
 
 import requests
 from behave import step
-from google.cloud import pubsub_v1
 from retrying import retry
 
 from acceptance_tests.features.steps.event_log import check_if_event_list_is_exact_match
@@ -15,12 +14,12 @@ from acceptance_tests.utilities.event_helper import check_individual_child_case_
 from acceptance_tests.utilities.mappings import NOTIFY_TEMPLATE
 from acceptance_tests.utilities.print_file_helper import create_expected_individual_response_csv, \
     _create_uac_print_materials_csv_line
+from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, store_first_message_in_context
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
-notify_stub_url = f'{Config.NOTIFY_STUB_SERVICE}'
 get_cases_url = f'{Config.CASEAPI_SERVICE}/cases/'
 
 
@@ -110,7 +109,7 @@ def send_print_fulfilment_request(context, fulfilment_code):
 
 @step('a UAC fulfilment request "{fulfilment_code}" message for a created case is sent')
 def create_uac_fulfilment_message(context, fulfilment_code):
-    requests.get(f'{notify_stub_url}/reset')
+    requests.get(f'{Config.NOTIFY_STUB_SERVICE}/reset')
 
     context.fulfilment_requested_case_id = context.uac_created_events[0]['payload']['uac']['caseId']
     context.individual_case_id = str(uuid.uuid4())
@@ -245,7 +244,7 @@ def check_notify_api_call(context, expected_template: str):
 
 @retry(stop_max_attempt_number=10, wait_fixed=1000)
 def check_notify_api_called_with_correct_template_id(expected_template_id):
-    response = requests.get(f'{notify_stub_url}/log')
+    response = requests.get(f'{Config.NOTIFY_STUB_SERVICE}/log')
     test_helper.assertEqual(response.status_code, 200, "Unexpected status code")
     response_json = response.json()
     test_helper.assertEqual(len(response_json), 1, "Incorrect number of responses")
@@ -265,7 +264,8 @@ def check_case_events(context):
 
 @step("a new individual child case for the fulfilment is emitted to RH and Action Scheduler")
 def fulfilment_child_case_is_emitted(context):
-    check_individual_child_case_is_emitted(context, context.fulfilment_requested_case_id, context.individual_case_id)
+    check_individual_child_case_is_emitted(context, context.fulfilment_requested_case_id,
+                                           context.individual_case_id)
 
 
 @step('a supplementary materials fulfilment request event with fulfilment code "{fulfilment_code}" is received by RM')
@@ -298,20 +298,26 @@ def check_multiple_questionnaire_fulfilment_events(context, expected_event_list)
         check_if_event_list_is_exact_match(expected_event_list, caze['id'])
 
 
-@step('correctly formatted individual response questionnaires are are created with "{fulfilment_code}"')
-def check_individual_questionnaire_print_requests(context, fulfilment_code):
+@step(
+    'correctly formatted individual response questionnaires are created for "{fulfilment_code}" '
+    'with questionnaire type "{questionnaire_type}"')
+def check_individual_questionnaire_print_requests(context, fulfilment_code, questionnaire_type):
     individual_case = requests.get(f'{get_cases_url}{context.individual_case_id}').json()
     uac, qid = get_qid_and_uac_from_emitted_child_uac(context)
+    test_helper.assertEqual(qid[:2], questionnaire_type, "Incorrect questionnaire type")
     expected_csv_lines = [create_expected_individual_response_csv(individual_case, uac, qid, fulfilment_code)]
 
     _check_print_files_have_all_the_expected_data(context, expected_csv_lines, fulfilment_code)
     _check_manifest_files_created(context, fulfilment_code)
 
 
-@step('correctly formatted individual UAC print responses are created with "{fulfilment_code}"')
-def check_individual_uac_print_requests(context, fulfilment_code):
+@step(
+    'correctly formatted individual UAC print responses are created for "{fulfilment_code}" '
+    'with questionnaire type "{questionnaire_type}"')
+def check_individual_uac_print_requests(context, fulfilment_code, questionnaire_type):
     individual_case = requests.get(f'{get_cases_url}{context.individual_case_id}').json()
     uac, qid = get_qid_and_uac_from_emitted_child_uac(context)
+    test_helper.assertEqual(qid[:2], questionnaire_type, "Incorrect questionnaire type")
     expected_csv_lines = [_create_uac_print_materials_csv_line(individual_case, uac, qid, fulfilment_code)]
 
     _check_print_files_have_all_the_expected_data(context, expected_csv_lines, fulfilment_code)
@@ -327,9 +333,6 @@ def check_individual_case_events_logged(context, expected_event_list):
 def qm_sends_fulfilment_confirmed(context):
     context.first_case = get_first_case(context)
     uac_created_message = context.uac_created_events[0]
-    publisher = pubsub_v1.PublisherClient()
-
-    topic_path = publisher.topic_path(Config.FULFILMENT_CONFIRMED_PROJECT_ID, Config.FULFILMENT_CONFIRMED_TOPIC_ID)
 
     data = json.dumps({"transactionId": str(uuid.uuid4()),
                        "dateTime": "2019-08-03T14:30:01",
@@ -338,20 +341,12 @@ def qm_sends_fulfilment_confirmed(context):
                        "channel": "QM",
                        "type": "FULFILMENT_CONFIRMED"})
 
-    future = publisher.publish(topic_path,
-                               data=data.encode('utf-8'))
-
-    future.result(timeout=30)
-
-    print(f'Message published to {topic_path}')
+    publish_to_pubsub(data, Config.FULFILMENT_CONFIRMED_PROJECT_ID, Config.FULFILMENT_CONFIRMED_TOPIC_ID)
 
 
 @step("PPO sends a fulfilment confirmed message via pubsub")
 def ppo_sends_fulfilment_confirmed(context):
     context.first_case = get_first_case(context)
-    publisher = pubsub_v1.PublisherClient()
-
-    topic_path = publisher.topic_path(Config.FULFILMENT_CONFIRMED_PROJECT_ID, Config.FULFILMENT_CONFIRMED_TOPIC_ID)
 
     data = json.dumps({"transactionId": str(uuid.uuid4()),
                        "dateTime": "2019-08-03T14:30:01",
@@ -360,9 +355,4 @@ def ppo_sends_fulfilment_confirmed(context):
                        "channel": "PPO",
                        "type": "FULFILMENT_CONFIRMED"})
 
-    future = publisher.publish(topic_path,
-                               data=data.encode('utf-8'))
-
-    future.result(timeout=30)
-
-    print(f'Message published to {topic_path}')
+    publish_to_pubsub(data, Config.FULFILMENT_CONFIRMED_PROJECT_ID, Config.FULFILMENT_CONFIRMED_TOPIC_ID)

--- a/acceptance_tests/utilities/event_helper.py
+++ b/acceptance_tests/utilities/event_helper.py
@@ -1,7 +1,7 @@
 import functools
 import logging
-import luhn
 
+import luhn
 import requests
 from structlog import wrap_logger
 
@@ -80,7 +80,7 @@ def get_and_check_case_created_messages(context):
 
     context.welsh_cases = [case['payload']['collectionCase'] for case in context.case_created_events
                            if (case['payload']['collectionCase']['treatmentCode'].startswith('HH_Q')
-                           or case['payload']['collectionCase']['treatmentCode'].startswith('SPG_Q'))
+                               or case['payload']['collectionCase']['treatmentCode'].startswith('SPG_Q'))
                            and case['payload']['collectionCase']['treatmentCode'].endswith('W')]
 
 
@@ -92,6 +92,17 @@ def get_and_check_uac_updated_messages(context):
                                                       collection_exercise_id=context.collection_exercise_id))
     context.uac_created_events = context.messages_received.copy()
     _test_uacs_updated_correct(context)
+    context.messages_received = []
+
+
+def get_last_uac_updated_event(context):
+    context.messages_received = []
+    start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,
+                                    functools.partial(store_all_uac_updated_msgs_by_collection_exercise_id,
+                                                      context=context,
+                                                      expected_msg_count=1,
+                                                      collection_exercise_id=context.collection_exercise_id))
+    context.last_uac_updated_event = context.messages_received[0]
     context.messages_received = []
 
 

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -1,0 +1,17 @@
+import logging
+
+from google.cloud import pubsub_v1
+from structlog import wrap_logger
+
+logger = wrap_logger(logging.getLogger(__name__))
+
+
+def publish_to_pubsub(message, project, topic, **kwargs):
+    publisher = pubsub_v1.PublisherClient()
+
+    topic_path = publisher.topic_path(project, topic)
+
+    future = publisher.publish(topic_path, data=message.encode('utf-8'), **kwargs)
+
+    future.result(timeout=30)
+    logger.info("Sent PubSub message", topic=topic, project=project)

--- a/config.py
+++ b/config.py
@@ -67,7 +67,9 @@ class Config:
     FULFILMENT_CONFIRMED_PROJECT_ID = os.getenv("FULFILMENT_CONFIRMED_PROJECT_ID",
                                                 "fulfilment-confirmed-project")
     FULFILMENT_CONFIRMED_TOPIC_ID = os.getenv("FULFILMENT_CONFIRMED_TOPIC",
-                                              "fulfilment-topic")
+                                              "fulfilment-confirmed-topic")
+    EQ_FULFILMENT_PROJECT_ID = os.getenv("EQ_FULFILMENT_PROJECT", "eq-fulfilment-project")
+    EQ_FULFILMENT_TOPIC_ID = os.getenv("EQ_FULFILMENT_TOPIC", "eq-fulfilment-topic")
 
     GOOGLE_APPLICATION_CREDENTIALS = os.getenv('GOOGLE_APPLICATION_CREDENTIALS')
     GOOGLE_SERVICE_ACCOUNT_JSON = os.getenv('GOOGLE_SERVICE_ACCOUNT_JSON')


### PR DESCRIPTION
# Motivation and Context
EQ need to be able to request individual fulfilment via a pubsub topic

# What has changed
* Add individual response request via EQ feature
* Add more coverage for SMS and individual fulfilment tests
* Put todos on erroneous questionnaire types

# How to test?
Run with linked docker dev/pubsub adapter branches

# Links
https://trello.com/c/GBhnJs8F/144-rmc-233-request-ir-via-eq-13
https://github.com/ONSdigital/census-rm-pubsub-adapter/pull/17
https://github.com/ONSdigital/census-rm-docker-dev/pull/60
