### PR TITLE
Add regression test for the incrementing CE actual response

### DIFF
--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -66,3 +66,16 @@ Feature: Case processor handles receipt message from pubsub service
     Then a uac_updated msg is emitted with active set to false
     And the events logged for the receipted case are [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED,PRINT_CASE_SELECTED,RESPONSE_RECEIVED]
     And no ActionInstruction is sent to FWMT
+
+  @regression
+  Scenario: CE Actual response count incrementation continues after the case is receipted
+    Given sample file "sample_1_english_CE_estab.csv" is loaded successfully
+    And a new qid and case are created for case type "CE" address level "E" qid type "CE1" and country "E"
+    And the receipt msg is put on the GCP pubsub
+    And a uac_updated msg is emitted with active set to false for the receipted qid
+    And an "UPDATE" field instruction is emitted
+    And a case_updated msg is emitted where "receiptReceived" is "True"
+    When a new qid and case are created for case type "CE" address level "E" qid type "Ind" and country "E"
+    And the receipt msg is put on the GCP pubsub
+    Then an "UPDATE" field instruction is emitted
+    And if the actual response count is incremented "True" or the case is marked receipted "True" then there should be a case updated message of case type "CE"

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -2,7 +2,7 @@ import functools
 import json
 import time
 
-from behave import then, step
+from behave import step
 from google.api_core.exceptions import GoogleAPIError
 from google.cloud import pubsub_v1
 
@@ -94,7 +94,7 @@ def receipt_ccs_offline_msg_published_to_gcp_pubsub(context):
     test_helper.assertTrue(context.sent_to_gcp)
 
 
-@then("a uac_updated msg is emitted with active set to false")
+@step("a uac_updated msg is emitted with active set to false")
 def uac_updated_msg_emitted(context):
     emitted_uac = _get_emitted_uac(context)
     test_helper.assertEqual(emitted_uac['caseId'], context.first_case['id'])
@@ -224,6 +224,8 @@ def get_first_case_and_linked_qid_to_receipt(context):
 
 @step('if required, a new qid and case are created for case type "{case_type}" address level "{address_level}"'
       ' qid type "{qid_type}" and country "{country_code}"')
+@step('a new qid and case are created for case type "{case_type}" address level "{address_level}"'
+      ' qid type "{qid_type}" and country "{country_code}"')
 def get_new_qid_and_case_as_required(context, case_type, address_level, qid_type, country_code):
     context.loaded_case = context.case_created_events[0]['payload']['collectionCase']
     # receipting_case will be over written if a child case is created
@@ -299,12 +301,14 @@ def check_ce_actual_responses_and_receipted(context, incremented, receipted, cas
     if receipted == 'AR >= E':
         receipted = emitted_case['ceActualResponses'] >= emitted_case['ceExpectedCapacity']
 
-    test_helper.assertEqual(str(emitted_case['receiptReceived']), str(receipted))
+    test_helper.assertEqual(str(emitted_case['receiptReceived']), str(receipted),
+                            "Receipted status on case updated event does not match expected")
 
 
 @step('if the field instruction "{action_instruction_type}" is not NONE a msg to field is emitted')
 @step('the field instruction is "{action_instruction_type}"')
 @step('an "{action_instruction_type}" field instruction is emitted')
+@step('a "{action_instruction_type}" field instruction is emitted')
 def check_receipt_to_field_msg(context, action_instruction_type):
     if action_instruction_type == 'NONE':
         check_no_msgs_sent_to_queue(context, Config.RABBITMQ_OUTBOUND_FIELD_QUEUE, functools.partial(


### PR DESCRIPTION
# Motivation and Context
The CE actual response count should be incremented regardless of whether the case is receipted or not.

# What has changed
* Add scenario for incrementing CE actual response count after case has been receipted

# How to test?
Build and run linked case processor branch, run tests

# Links
https://trello.com/c/bhDgGx3H/1035-defect-ceactualresponse-count-not-increasi
https://github.com/ONSdigital/census-rm-case-processor/pull/164