### PR TITLE
Add full tests for SMS UAC requests

### DIFF
--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -28,12 +28,12 @@ Feature: Handle fulfilment request events
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
     And the individual case has these events logged [RM_UAC_CREATED]
 
-    Examples: Household UAC fulfilment codes: <fulfilment code>
+    Examples: Individual UAC fulfilment codes: <fulfilment code>
       | fulfilment code | questionnaire type | template ID                          |
       | UACIT1          | 21                 | 21447bc2-e7c7-41ba-8c5e-7a5893068525 |
 
     @regression
-    Examples: Household UAC fulfilment codes: <fulfilment code>
+    Examples: Individual UAC fulfilment codes: <fulfilment code>
       | fulfilment code | questionnaire type | template ID                          |
       | UACIT2          | 22                 | 23f96daf-9674-4087-acfc-ffe98a52cf16 |
       | UACIT2W         | 23                 | ef045f43-ffa8-4047-b8e2-65bfbce0f026 |

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -3,48 +3,48 @@ Feature: Handle fulfilment request events
   Scenario Outline: Household UAC SMS requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
-    Then notify api was called with template id "<template ID>"
+    Then notify api was called with SMS template "<SMS template>"
     And a UAC updated message with "<questionnaire type>" questionnaire type is emitted
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED]
 
     @smoke
     Examples: Household UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | template ID                          |
-      | UACHHT1         | 01                 | 21447bc2-e7c7-41ba-8c5e-7a5893068525 |
+      | fulfilment code | questionnaire type | SMS template      |
+      | UACHHT1         | 01                 | household English |
 
     @regression
     Examples: Household UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | template ID                          |
-      | UACHHT2         | 02                 | 23f96daf-9674-4087-acfc-ffe98a52cf16 |
-      | UACHHT2W        | 03                 | ef045f43-ffa8-4047-b8e2-65bfbce0f026 |
-      | UACHHT4         | 04                 | 1ccd02a4-9b90-4234-ab7a-9215cb498f14 |
+      | fulfilment code | questionnaire type | SMS template               |
+      | UACHHT2         | 02                 | household Wales in English |
+      | UACHHT2W        | 03                 | household Wales in Welsh   |
+      | UACHHT4         | 04                 | household Northern Ireland |
 
-    Scenario Outline: Individual UAC SMS requests
+  Scenario Outline: Individual UAC SMS requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
     Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
-    And notify api was called with template id "<template ID>"
+    And notify api was called with SMS template "<SMS template>"
     And a UAC updated message with "<questionnaire type>" questionnaire type is emitted for the individual case
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
     And the individual case has these events logged [RM_UAC_CREATED]
 
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | template ID                          |
-      | UACIT1          | 21                 | 21447bc2-e7c7-41ba-8c5e-7a5893068525 |
+      | fulfilment code | questionnaire type | SMS template       |
+      | UACIT1          | 21                 | individual English |
 
     @regression
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | template ID                          |
-      | UACIT2          | 22                 | 23f96daf-9674-4087-acfc-ffe98a52cf16 |
-      | UACIT2W         | 23                 | ef045f43-ffa8-4047-b8e2-65bfbce0f026 |
-      | UACIT4          | 24                 | 1ccd02a4-9b90-4234-ab7a-9215cb498f14 |
+      | fulfilment code | questionnaire type | SMS template                |
+      | UACIT2          | 22                 | individual Wales in English |
+      | UACIT2W         | 23                 | individual Wales in Welsh   |
+      | UACIT4          | 24                 | individual Northern Ireland |
 
   Scenario: Individual Response Fulfilment is received Log event without contact details, save new case, emit new case
     Given sample file "sample_input_england_census_spec.csv" is loaded
     And messages are emitted to RH and Action Scheduler with [01] questionnaire types
     When a UAC fulfilment request "UACIT1" message for a created case is sent
     Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
-    And notify api was called with template id "21447bc2-e7c7-41ba-8c5e-7a5893068525"
+    And notify api was called with SMS template "individual English"
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
     And the individual case has these events logged [RM_UAC_CREATED]
 

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -1,12 +1,43 @@
 Feature: Handle fulfilment request events
 
-  @smoke
-  Scenario: Log event when a fulfilment request event is received
-    Given sample file "sample_input_england_census_spec.csv" is loaded
-    And messages are emitted to RH and Action Scheduler with [01] questionnaire types
-    When a UAC fulfilment request "UACHHT1" message for a created case is sent
-    And notify api was called with template id "21447bc2-e7c7-41ba-8c5e-7a5893068525"
+  Scenario Outline: Household UAC SMS requests
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
+    Then notify api was called with template id "<template ID>"
+    And a UAC updated message with "<questionnaire type>" questionnaire type is emitted
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED]
+
+    @smoke
+    Examples: Household UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | template ID                          |
+      | UACHHT1         | 01                 | 21447bc2-e7c7-41ba-8c5e-7a5893068525 |
+
+    @regression
+    Examples: Household UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | template ID                          |
+      | UACHHT2         | 02                 | 23f96daf-9674-4087-acfc-ffe98a52cf16 |
+      | UACHHT2W        | 03                 | ef045f43-ffa8-4047-b8e2-65bfbce0f026 |
+      | UACHHT4         | 04                 | 1ccd02a4-9b90-4234-ab7a-9215cb498f14 |
+
+    Scenario Outline: Individual UAC SMS requests
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
+    Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
+    And notify api was called with template id "<template ID>"
+    And a UAC updated message with "<questionnaire type>" questionnaire type is emitted for the individual case
+    And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
+    And the individual case has these events logged [RM_UAC_CREATED]
+
+    Examples: Household UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | template ID                          |
+      | UACIT1          | 21                 | 21447bc2-e7c7-41ba-8c5e-7a5893068525 |
+
+    @regression
+    Examples: Household UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | template ID                          |
+      | UACIT2          | 22                 | 23f96daf-9674-4087-acfc-ffe98a52cf16 |
+      | UACIT2W         | 23                 | ef045f43-ffa8-4047-b8e2-65bfbce0f026 |
+      | UACIT4          | 24                 | 1ccd02a4-9b90-4234-ab7a-9215cb498f14 |
 
   Scenario: Individual Response Fulfilment is received Log event without contact details, save new case, emit new case
     Given sample file "sample_input_england_census_spec.csv" is loaded

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -14,10 +14,10 @@ Feature: Handle fulfilment request events
 
     @regression
     Examples: Household UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template               |
-      | UACHHT2         | 02                 | household Wales in English |
-      | UACHHT2W        | 03                 | household Wales in Welsh   |
-      | UACHHT4         | 04                 | household Northern Ireland |
+      | fulfilment code | questionnaire type | SMS template                |
+      | UACHHT2         | 02                 | household Welsh and English |
+      | UACHHT2W        | 03                 | household Welsh             |
+      | UACHHT4         | 04                 | household Northern Ireland  |
 
   Scenario Outline: Individual UAC SMS requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
@@ -34,10 +34,10 @@ Feature: Handle fulfilment request events
 
     @regression
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template                |
-      | UACIT2          | 22                 | individual Wales in English |
-      | UACIT2W         | 23                 | individual Wales in Welsh   |
-      | UACIT4          | 24                 | individual Northern Ireland |
+      | fulfilment code | questionnaire type | SMS template                 |
+      | UACIT2          | 22                 | individual Welsh and English |
+      | UACIT2W         | 23                 | individual Welsh             |
+      | UACIT4          | 24                 | individual Northern Ireland  |
 
   Scenario: Individual Response Fulfilment is received Log event without contact details, save new case, emit new case
     Given sample file "sample_input_england_census_spec.csv" is loaded

--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -12,6 +12,7 @@ from acceptance_tests.features.steps.print_file import _check_print_files_have_a
     _check_manifest_files_created
 from acceptance_tests.utilities.event_helper import check_individual_child_case_is_emitted, \
     get_qid_and_uac_from_emitted_child_uac
+from acceptance_tests.utilities.mappings import NOTIFY_TEMPLATE
 from acceptance_tests.utilities.print_file_helper import create_expected_individual_response_csv, \
     _create_uac_print_materials_csv_line
 from acceptance_tests.utilities.rabbit_context import RabbitContext
@@ -237,9 +238,9 @@ def check_case_events_logged(context):
     test_helper.fail('Did not find fulfilment request event')
 
 
-@step('notify api was called with template id "{expected_template_id}"')
-def check_notify_api_call(context, expected_template_id):
-    check_notify_api_called_with_correct_template_id(expected_template_id)
+@step('notify api was called with SMS template "{expected_template}"')
+def check_notify_api_call(context, expected_template: str):
+    check_notify_api_called_with_correct_template_id(NOTIFY_TEMPLATE['_'.join(expected_template.lower().split())])
 
 
 @retry(stop_max_attempt_number=10, wait_fixed=1000)

--- a/acceptance_tests/utilities/mappings.py
+++ b/acceptance_tests/utilities/mappings.py
@@ -444,3 +444,17 @@ QUESTIONNAIRE_TYPE_TO_FORM_TYPE = {
     "32": 'C',
     "34": 'C',
 }
+
+NOTIFY_TEMPLATE = {
+    # Household
+    "household_english": "21447bc2-e7c7-41ba-8c5e-7a5893068525",
+    "household_wales_in_english": "23f96daf-9674-4087-acfc-ffe98a52cf16",
+    "household_wales_in_welsh": "ef045f43-ffa8-4047-b8e2-65bfbce0f026",
+    "household_northern_ireland": "1ccd02a4-9b90-4234-ab7a-9215cb498f14",
+
+    # Individual (same as household?)
+    "individual_english": "21447bc2-e7c7-41ba-8c5e-7a5893068525",
+    "individual_wales_in_english": "23f96daf-9674-4087-acfc-ffe98a52cf16",
+    "individual_wales_in_welsh": "ef045f43-ffa8-4047-b8e2-65bfbce0f026",
+    "individual_northern_ireland": "1ccd02a4-9b90-4234-ab7a-9215cb498f14",
+}

--- a/acceptance_tests/utilities/mappings.py
+++ b/acceptance_tests/utilities/mappings.py
@@ -448,13 +448,13 @@ QUESTIONNAIRE_TYPE_TO_FORM_TYPE = {
 NOTIFY_TEMPLATE = {
     # Household
     "household_english": "21447bc2-e7c7-41ba-8c5e-7a5893068525",
-    "household_wales_in_english": "23f96daf-9674-4087-acfc-ffe98a52cf16",
-    "household_wales_in_welsh": "ef045f43-ffa8-4047-b8e2-65bfbce0f026",
+    "household_welsh_and_english": "23f96daf-9674-4087-acfc-ffe98a52cf16",
+    "household_welsh": "ef045f43-ffa8-4047-b8e2-65bfbce0f026",
     "household_northern_ireland": "1ccd02a4-9b90-4234-ab7a-9215cb498f14",
 
     # Individual (same as household?)
     "individual_english": "21447bc2-e7c7-41ba-8c5e-7a5893068525",
-    "individual_wales_in_english": "23f96daf-9674-4087-acfc-ffe98a52cf16",
-    "individual_wales_in_welsh": "ef045f43-ffa8-4047-b8e2-65bfbce0f026",
+    "individual_welsh_and_english": "23f96daf-9674-4087-acfc-ffe98a52cf16",
+    "individual_welsh": "ef045f43-ffa8-4047-b8e2-65bfbce0f026",
     "individual_northern_ireland": "1ccd02a4-9b90-4234-ab7a-9215cb498f14",
 }


### PR DESCRIPTION
# Motivation and Context
The QID types for the wales in welsh fulfilment codes were wrong and untested

# What has changed
* Add full tests for SMS UAC requests 

# How to test?
Build and run AT's with linked Notify Processor branch 

# Links
https://trello.com/c/Rjn63QiZ/1039-welsh-walesness-should-be-welshed-to-heck-sms-fulfilments
https://github.com/ONSdigital/census-rm-notify-processor/pull/25