### PR TITLE
Blank questionnaire event ordering fixes

### DIFF
--- a/acceptance_tests/features/blank_questionnaire.feature
+++ b/acceptance_tests/features/blank_questionnaire.feature
@@ -127,8 +127,10 @@ Feature: Handling Blank Questionnaire Scenario
     And if required, a new qid and case are created for case type "<case type>" address level "<address level>" qid type "<qid type>" and country "<country>"
     And an unaddressed QID request message of questionnaire type <form type> is sent
     And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
-    And the offline receipt msg for the receipted case is put on the GCP pubsub for an unlinked qid
+    And the offline receipt msg for the unlinked is put on the GCP pubsub
+    And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     And a blank questionnaire receipts comes in for an unlinked qid
+    And a UACUpdated message not linked to a case is emitted to RH and Action Scheduler
     When a Questionnaire Linked message is sent for blank questionnaire
     Then if the field instruction "<blank instruction>" is not NONE a msg to field is emitted
 

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -48,9 +48,8 @@ def offline_msg_published_to_gcp_pubsub_for_receipted_cases(context):
     test_helper.assertTrue(context.sent_to_gcp)
 
 
-@step("the offline receipt msg for the receipted case is put on the GCP pubsub for an unlinked qid")
+@step("the offline receipt msg for the unlinked is put on the GCP pubsub")
 def offline_msg_published_to_gcp_pubsub_for_unlinked_qids(context):
-    context.first_case = context.receipting_case
     questionnaire_id = context.expected_questionnaire_id
     _publish_offline_receipt(context, channel='PQRS', unreceipt=False, questionnaire_id=questionnaire_id)
     test_helper.assertTrue(context.sent_to_gcp)
@@ -58,10 +57,6 @@ def offline_msg_published_to_gcp_pubsub_for_unlinked_qids(context):
 
 @step("a blank questionnaire receipts comes in for an unlinked qid")
 def offline_receipt_for_an_unlinked_qid(context):
-
-    # TODO this a temporary fix to ensure event ordering, should be replaced with more intelligent waits
-    sleep(1)
-
     context.first_case = context.receipting_case
     questionnaire_id = context.expected_questionnaire_id
     _publish_offline_receipt(context, channel="QM", questionnaire_id=questionnaire_id, unreceipt=True)

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -1,6 +1,5 @@
 import functools
 import json
-from time import sleep
 
 from behave import step
 

--- a/acceptance_tests/features/steps/unaddressed.py
+++ b/acceptance_tests/features/steps/unaddressed.py
@@ -45,10 +45,6 @@ def send_linked_message_for_alternative_case(context):
 
 @step("a Questionnaire Linked message is sent for blank questionnaire")
 def send_linked_message_for_blank_questionnaire(context):
-
-    # TODO this a temporary fix to ensure event ordering, should be replaced with more intelligent waits
-    time.sleep(1)
-
     check_blank_link_message_is_received(context)
     context.linked_case_id = context.linked_case['id']
 

--- a/acceptance_tests/utilities/rabbit_helper.py
+++ b/acceptance_tests/utilities/rabbit_helper.py
@@ -107,7 +107,8 @@ def check_no_msgs_sent_to_queue(context, queue, on_message_callback, timeout=5):
         on_message_callback=on_message_callback)
     rabbit.channel.start_consuming()
     if len(context.messages_received) > 0:
-        test_helper.fail(f'Expected no messages on the queue {queue}, found {len(context.messages_received)}')
+        test_helper.fail(f'Expected no messages on the queue {queue}, found {len(context.messages_received)}'
+                         f', message(s): {context.messages_received}')
 
 
 def _timeout_callback_expected(rabbit):


### PR DESCRIPTION
# Motivation and Context
Some of the blank questionnaire flows are dependent on the order in which we process the events, we had a stopgap solution of sleeps to ensure the events were processed in order before. This PR adds in steps which ensure the events are processed in order in a more robust way by waiting for the UAC updated events that result. I believe this change to one scenario also solves the knock-on failures it caused it others too.

# What has changed
* Add steps to ensure events are processed in the required order
* Improve step wording
* Remove sleeps
* Add more error detail output

# How to test?
Run the blank questionnaire feature locally a few times, the intermittent failure should not have returned

# Links
https://trello.com/c/DMMthmeu/1071-fix-ats-event-ordering-bug