### PR TITLE
Update test to check for dummy UPRN

### DIFF
--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -365,7 +365,7 @@ def retrieve_case_from_source_case_id_and_no_event_details(context):
     test_helper.assertEqual(context.first_case['msoa'], source_case['msoa'])
     test_helper.assertEqual(context.first_case['lsoa'], source_case['lsoa'])
     test_helper.assertEqual(context.first_case['organisationName'], source_case['address']['organisationName'])
-    test_helper.assertEqual(context.first_case['uprn'], None)
+    test_helper.assertEqual(context.first_case['uprn'], f"999{context.first_case['caseRef']}")
     test_helper.assertEqual(context.first_case['secureEstablishment'], source_case['metadata']['secureEstablishment'])
 
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If a new address event is ingested (with source case or without), unless a UPRN is on the event then there isn't one set.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Test updated to add check for correct UPRN added.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
[Run with case processor built on branch of the same name](https://github.com/ONSdigital/census-rm-case-processor/pull/169).
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/nVFvsv29/1025-apply-dummy-uprn-5
# Screenshots (if appropriate):