### PR TITLE
(IC03.1/IC04.1) Generate CE UNIT Addressed ICL Print Files 

### DIFF
--- a/acceptance_tests/features/print_file.feature
+++ b/acceptance_tests/features/print_file.feature
@@ -24,8 +24,6 @@ Feature: Scheduled print and manifest files can be generated and uploaded
       | P_IC_ICL2B     | ICL2W       | [02]                | sample_input_wales_census_spec.csv |
       | P_IC_ICL4      | ICL4N       | [04]                | sample_input_ni_census_spec.csv    |
       | D_CE1A_ICLCR2B | CE1_IC02    | [32]                | sample_1_welsh_CE_estab.csv        |
-      | D_ICA_ICLR1    | CE_IC03_1   | [21]                | sample_1_english_CE_unit.csv       |
-      | D_ICA_ICLR2B   | CE_IC04_1   | [22]                | sample_1_welsh_CE_unit.csv         |
       | P_ICCE_ICL1    | SPG_IC11    | [01]                | sample_1_english_SPG_unit.csv      |
       | P_ICCE_ICL2B   | SPG_IC12    | [02]                | sample_1_welsh_SPG_unit.csv        |
 
@@ -47,7 +45,9 @@ Feature: Scheduled print and manifest files can be generated and uploaded
     @regression
     Examples: CE Estab initial contact Letters: <pack code>
       | pack code    | action type | questionnaire type | sample file                       | individual qid type |
+      | D_ICA_ICLR1  | CE_IC03_1   | 21                 | sample_1_english_CE_unit.csv      | 21                  |
       | D_ICA_ICLR2B | CE_IC04     | 32                 | sample_3_welsh_CE_estab.csv       | 22                  |
+      | D_ICA_ICLR2B | CE_IC04_1   | 22                 | sample_1_welsh_CE_unit.csv        | 22                  |
       | D_CE4A_ICLR4 | CE_IC05     | 34                 | sample_3_ni_CE_estab_resident.csv | 24                  |
       | D_CE4A_ICLS4 | CE_IC06     | 34                 | sample_3_ni_CE_estab_student.csv  | 24                  |
 

--- a/acceptance_tests/features/print_file.feature
+++ b/acceptance_tests/features/print_file.feature
@@ -28,7 +28,7 @@ Feature: Scheduled print and manifest files can be generated and uploaded
       | P_ICCE_ICL2B   | SPG_IC12    | [02]                | sample_1_welsh_SPG_unit.csv        |
 
 
-  Scenario Outline: Generate print files and log events for initial contact letters CE Estabs
+  Scenario Outline: Generate print files and log events for initial contact letters CE cases
     Given sample file "<sample file>" is loaded
     And messages are emitted to RH and Action Scheduler with <questionnaire type> questionnaire types
     When set action rule of type "<action type>" when the case loading queues are drained
@@ -38,12 +38,12 @@ Feature: Scheduled print and manifest files can be generated and uploaded
     And the expected number of "RM_UAC_CREATED" and [PRINT_CASE_SELECTED,SAMPLE_LOADED] events are logged against the case
     And the files have all been copied to the bucket
 
-    Examples: CE Estab initial contact Letters: <pack code>
+    Examples: CE initial contact Letters: <pack code>
       | pack code   | action type | questionnaire type | sample file                   | individual qid type |
       | D_ICA_ICLR1 | CE_IC03     | 31                 | sample_3_english_CE_estab.csv | 21                  |
 
     @regression
-    Examples: CE Estab initial contact Letters: <pack code>
+    Examples: CE initial contact Letters: <pack code>
       | pack code    | action type | questionnaire type | sample file                       | individual qid type |
       | D_ICA_ICLR1  | CE_IC03_1   | 21                 | sample_1_english_CE_unit.csv      | 21                  |
       | D_ICA_ICLR2B | CE_IC04     | 32                 | sample_3_welsh_CE_estab.csv       | 22                  |


### PR DESCRIPTION
# Motivation and Context
These ActionTypes needed to be changed to generate and address line for each instance of expected response recorded against the unit whereas before they were not dependent on expected capacity

# What has changed
IC03.1/IC04.1 moved to appropriate test 

# How to test?
Build with other repos on card and run ATs

# Links
https://trello.com/c/FPqeHTfQ/1046-ic031-i041-generate-ce-unit-addressed-icl-print-files-3
https://collaborate2.ons.gov.uk/confluence/display/SDC/RM+Census+Initial+Contact+Run+Book+-+2021
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?pageId=34832584