### PR TITLE
Individual response reminders

### DIFF
--- a/acceptance_tests/features/initial_contact.feature
+++ b/acceptance_tests/features/initial_contact.feature
@@ -97,33 +97,6 @@ Feature: Scheduled initial contact print and manifest files can be generated and
     And two "RM_UAC_CREATED" events [PRINT_CASE_SELECTED,SAMPLE_LOADED] are logged per case
 
 
-  Scenario Outline: Generate print files and log events for scheduled reminder letters
-    Given sample file "<sample file>" is loaded and correct qids <questionnaire types> set
-    When set action rule of type "<pack code>"
-    Then UAC Updated events emitted for the 2 cases with matching treatment codes
-    And correctly formatted "<pack code>" reminder letter print files are created
-    And there is a correct "<pack code>" manifest file for each csv file written
-    And "PRINT_CASE_SELECTED" events are logged against the cases included in the reminder
-
-    Examples: Reminder letter: <pack code>
-      | pack code   | questionnaire types | sample file                          |
-      | P_RL_1RL1_1 | [01]                | sample_input_england_census_spec.csv |
-
-    @regression
-    Examples: Reminder letter: <pack code>
-      | pack code     | questionnaire types | sample file                        |
-      | P_RL_2RL2B_3a | [02]                | sample_input_wales_census_spec.csv |
-
-
-  Scenario: Generate print files and log events for scheduled questionnaire letters
-    Given sample file "sample_for_reminder_questionnaire.csv" is loaded successfully
-    When set action rule of type "P_QU_H2"
-    Then 2 UAC Updated events are emitted for the 3 cases with matching treatment codes
-    And correctly formatted "P_QU_H2" reminder questionnaire print files are created
-    And there is a correct "P_QU_H2" manifest file for each csv file written
-    And "PRINT_CASE_SELECTED" events are logged against the cases included in the reminder
-
-
   Scenario Outline: Generate print files and log events for response driven reminders
     Given sample file "<sample file>" is loaded successfully
     When set action rule of type "<pack code>"
@@ -145,20 +118,6 @@ Feature: Scheduled initial contact print and manifest files can be generated and
       | P_RD_2RL1_3  | 1                        | sample_input_england_response_driven_reminders.csv |
       | P_RD_2RL2B_3 | 1                        | sample_input_wales_census_spec.csv                 |
 
-
-  Scenario Outline: Generate print files and log events for response driven reminders with survey started
-    Given sample file "<sample file>" is loaded successfully
-    And a survey launched for a created case is received for cases with lsoa <lsoa list>
-    When set action rule of type "<pack code>"
-    Then correctly formatted "<pack code>" print files are created for packcode and where survey was launched
-    And there is a correct "<pack code>" manifest file for each csv file written
-
-    Examples: Reminder contact letter: <pack code>
-      | pack code   | lsoa list                                 | sample file                                        |
-      | P_RL_1RL1A  | [E01014540,E01014541]                     | sample_input_england_response_driven_reminders.csv |
-      | P_RL_1RL2BA | [E01014669,W01014669]                     | sample_input_wales_census_spec.csv                 |
-      | P_RL_2RL1A  | [E01014543,E01014544]                     | sample_input_england_response_driven_reminders.csv |
-      | P_RL_2RL2BA | [E01033361,E01015005,W01033361,W01015005] | sample_input_wales_census_spec.csv                 |
 
   Scenario Outline: Address frame delta initial contact print files
     Given sample file "sample_for_print_stories.csv" is loaded successfully

--- a/acceptance_tests/features/initial_contact.feature
+++ b/acceptance_tests/features/initial_contact.feature
@@ -1,4 +1,4 @@
-Feature: Scheduled print and manifest files can be generated and uploaded
+Feature: Scheduled initial contact print and manifest files can be generated and uploaded
 
   Scenario Outline: Generate print files and log events for initial contact letters
     Given sample file "<sample file>" is loaded and correct qids <questionnaire types> set
@@ -159,19 +159,6 @@ Feature: Scheduled print and manifest files can be generated and uploaded
       | P_RL_1RL2BA | [E01014669,W01014669]                     | sample_input_wales_census_spec.csv                 |
       | P_RL_2RL1A  | [E01014543,E01014544]                     | sample_input_england_response_driven_reminders.csv |
       | P_RL_2RL2BA | [E01033361,E01015005,W01033361,W01015005] | sample_input_wales_census_spec.csv                 |
-
-  Scenario Outline: Generate print files and log events for scheduled reminder letters checking for MILITARY SFA
-    Given sample file "<sample file>" is loaded successfully
-    When set SPG MILITARY SFA action rule of type "<pack code>" when the case loading queues are drained
-    And UAC Updated events emitted for the <number of matching cases> cases with matching treatment codes
-    Then correctly formatted "<pack code>" reminder letter print files are created
-    And there is a correct "<pack code>" manifest file for each csv file written
-    And "PRINT_CASE_SELECTED" events are logged against the cases included in the reminder
-
-    Examples: Reminder letter: <pack code>
-      | pack code   | number of matching cases | sample file                           |
-      | P_RL_1RL1_1 | 1                        | sample_1_english_SPG_MILITARY_SFA.csv |
-
 
   Scenario Outline: Address frame delta initial contact print files
     Given sample file "sample_for_print_stories.csv" is loaded successfully

--- a/acceptance_tests/features/print_reminder.feature
+++ b/acceptance_tests/features/print_reminder.feature
@@ -1,0 +1,82 @@
+Feature: Scheduled reminder print and manifest files can be generated and uploaded
+
+  Scenario Outline: Generate print files and log events for scheduled reminder letters
+    Given sample file "<sample file>" is loaded and correct qids <questionnaire types> set
+    When set action rule of type "<pack code>"
+    Then UAC Updated events emitted for the 2 cases with matching treatment codes
+    And correctly formatted "<pack code>" reminder letter print files are created
+    And there is a correct "<pack code>" manifest file for each csv file written
+    And "PRINT_CASE_SELECTED" events are logged against the cases included in the reminder
+
+    Examples: Reminder letter: <pack code>
+      | pack code   | questionnaire types | sample file                          |
+      | P_RL_1RL1_1 | [01]                | sample_input_england_census_spec.csv |
+
+    @regression
+    Examples: Reminder letter: <pack code>
+      | pack code     | questionnaire types | sample file                        |
+      | P_RL_2RL2B_3a | [02]                | sample_input_wales_census_spec.csv |
+
+
+  Scenario: Generate print files and log events for scheduled questionnaire letters
+    Given sample file "sample_for_reminder_questionnaire.csv" is loaded successfully
+    When set action rule of type "P_QU_H2"
+    Then 2 UAC Updated events are emitted for the 3 cases with matching treatment codes
+    And correctly formatted "P_QU_H2" reminder questionnaire print files are created
+    And there is a correct "P_QU_H2" manifest file for each csv file written
+    And "PRINT_CASE_SELECTED" events are logged against the cases included in the reminder
+
+
+  Scenario Outline: Generate print files and log events for response driven reminders
+    Given sample file "<sample file>" is loaded successfully
+    When set action rule of type "<pack code>"
+    Then UAC Updated events emitted for the <number of matching cases> cases with matching treatment codes
+    Then correctly formatted "<pack code>" reminder letter print files are created
+    And there is a correct "<pack code>" manifest file for each csv file written
+    And "PRINT_CASE_SELECTED" events are logged against the cases included in the reminder
+
+    Examples: Reminder contact letter: <pack code>
+      | pack code   | number of matching cases | sample file                                        |
+      | P_RD_2RL1_1 | 3                        | sample_input_england_response_driven_reminders.csv |
+
+    @regression
+    Examples: Reminder contact letter: <pack code>
+      | pack code    | number of matching cases | sample file                                        |
+      | P_RD_2RL2B_1 | 1                        | sample_input_wales_census_spec.csv                 |
+      | P_RD_2RL1_2  | 2                        | sample_input_england_response_driven_reminders.csv |
+      | P_RD_2RL2B_2 | 2                        | sample_input_wales_census_spec.csv                 |
+      | P_RD_2RL1_3  | 1                        | sample_input_england_response_driven_reminders.csv |
+      | P_RD_2RL2B_3 | 1                        | sample_input_wales_census_spec.csv                 |
+
+
+  Scenario Outline: Generate print files and log events for response driven reminders with survey started
+    Given sample file "<sample file>" is loaded successfully
+    And a survey launched for a created case is received for cases with lsoa <lsoa list>
+    When set action rule of type "<pack code>"
+    Then correctly formatted "<pack code>" print files are created for packcode and where survey was launched
+    And there is a correct "<pack code>" manifest file for each csv file written
+
+    Examples: Reminder contact letter: <pack code>
+      | pack code   | lsoa list                                 | sample file                                        |
+      | P_RL_1RL1A  | [E01014540,E01014541]                     | sample_input_england_response_driven_reminders.csv |
+      | P_RL_1RL2BA | [E01014669,W01014669]                     | sample_input_wales_census_spec.csv                 |
+      | P_RL_2RL1A  | [E01014543,E01014544]                     | sample_input_england_response_driven_reminders.csv |
+      | P_RL_2RL2BA | [E01033361,E01015005,W01033361,W01015005] | sample_input_wales_census_spec.csv                 |
+    
+
+  Scenario Outline: Generate print files and log events for scheduled reminder letters checking for MILITARY SFA
+    Given sample file "<sample file>" is loaded successfully
+    When set SPG MILITARY SFA action rule of type "<pack code>" when the case loading queues are drained
+    And UAC Updated events emitted for the <number of matching cases> cases with matching treatment codes
+    Then correctly formatted "<pack code>" reminder letter print files are created
+    And there is a correct "<pack code>" manifest file for each csv file written
+    And "PRINT_CASE_SELECTED" events are logged against the cases included in the reminder
+
+    Examples: Reminder letter: <pack code>
+      | pack code   | number of matching cases | sample file                           |
+      | P_RL_1RL1_1 | 1                        | sample_1_english_SPG_MILITARY_SFA.csv |
+
+
+#  Scenario Outline: Individual response reminder print run
+#    Given sample file "<sample file>" is loaded successfully
+#    And an individual SMS UAC fulfilment request "UACIT1" message is sent by EQ

--- a/acceptance_tests/features/print_reminder.feature
+++ b/acceptance_tests/features/print_reminder.feature
@@ -77,19 +77,35 @@ Feature: Scheduled reminder print and manifest files can be generated and upload
       | P_RL_1RL1_1 | 1                        | sample_1_english_SPG_MILITARY_SFA.csv |
 
 
-  Scenario Outline: Individual response reminder print run
+  Scenario Outline: Individual response reminder for HI cases created by EQ IR SMS request
     Given sample file "<sample file>" is loaded successfully
-    And an individual SMS UAC fulfilment request "UACIT1" message is sent by EQ
+    And an individual SMS UAC fulfilment request "<fulfilment code>" message is sent by EQ
     And an EQ individual response HI case created and uac updated event are emitted
-    When the individual response reminder action rule of type "<pack code>" is set
-    Then correctly formatted "<pack code>" individual reminder letter print files are created
-    And there is a correct "<pack code>" manifest file for each csv file written
+    When the individual response reminder action rule of type "<reminder pack code>" is set
+    Then correctly formatted "<reminder pack code>" individual reminder letter print files are created
+    And there is a correct "<reminder pack code>" manifest file for each csv file written
 
-    Examples: Individual Response Reminder letter: <pack code>
-      | pack code   | sample file                  |
-      | P_RL_1IRL1  | sample_1_english_HH_unit.csv |
+    Examples: Individual Response Reminder letter: <reminder pack code>
+      | reminder pack code | fulfilment code | sample file                  |
+      | P_RL_1IRL1         | UACIT1          | sample_1_english_HH_unit.csv |
 
     @regression
-    Examples: Individual Response Reminder letter: <pack code>
-      | pack code   | sample file                  |
-      | P_RL_1IRL2B | sample_1_welsh_HH_unit.csv   |
+    Examples: Individual Response Reminder letter: <reminder pack code>
+      | reminder pack code | fulfilment code | sample file                |
+      | P_RL_1IRL2B        | UACIT2          | sample_1_welsh_HH_unit.csv |
+      | P_RL_1IRL2B        | UACIT2W         | sample_1_welsh_HH_unit.csv |
+
+
+  Scenario Outline: Individual response reminder for HI cases created by EQ IR print request
+    Given sample file "<sample file>" is loaded successfully
+    And an individual print UAC fulfilment request "<fulfilment code>" message is sent by EQ
+    And an EQ individual response HI case created and uac updated event are emitted
+    When the individual response reminder action rule of type "<reminder pack code>" is set
+    Then correctly formatted "<reminder pack code>" individual reminder letter print files are created
+    And there is a correct "<reminder pack code>" manifest file for each csv file written
+
+    @regression
+    Examples: Individual Response Reminder letter: <reminder pack code>
+      | reminder pack code | fulfilment code | sample file                  |
+      | P_RL_1IRL1         | P_UAC_UACIP1    | sample_1_english_HH_unit.csv |
+      | P_RL_1IRL2B        | P_UAC_UACIP2B   | sample_1_welsh_HH_unit.csv   |

--- a/acceptance_tests/features/print_reminder.feature
+++ b/acceptance_tests/features/print_reminder.feature
@@ -62,7 +62,7 @@ Feature: Scheduled reminder print and manifest files can be generated and upload
       | P_RL_1RL2BA | [E01014669,W01014669]                     | sample_input_wales_census_spec.csv                 |
       | P_RL_2RL1A  | [E01014543,E01014544]                     | sample_input_england_response_driven_reminders.csv |
       | P_RL_2RL2BA | [E01033361,E01015005,W01033361,W01015005] | sample_input_wales_census_spec.csv                 |
-    
+
 
   Scenario Outline: Generate print files and log events for scheduled reminder letters checking for MILITARY SFA
     Given sample file "<sample file>" is loaded successfully
@@ -77,6 +77,19 @@ Feature: Scheduled reminder print and manifest files can be generated and upload
       | P_RL_1RL1_1 | 1                        | sample_1_english_SPG_MILITARY_SFA.csv |
 
 
-#  Scenario Outline: Individual response reminder print run
-#    Given sample file "<sample file>" is loaded successfully
-#    And an individual SMS UAC fulfilment request "UACIT1" message is sent by EQ
+  Scenario Outline: Individual response reminder print run
+    Given sample file "<sample file>" is loaded successfully
+    And an individual SMS UAC fulfilment request "UACIT1" message is sent by EQ
+    And an EQ individual response HI case created and uac updated event are emitted
+    When the individual response reminder action rule of type "<pack code>" is set
+    Then correctly formatted "<pack code>" individual reminder letter print files are created
+    And there is a correct "<pack code>" manifest file for each csv file written
+
+    Examples: Individual Response Reminder letter: <pack code>
+      | pack code   | sample file                  |
+      | P_RL_1IRL1  | sample_1_english_HH_unit.csv |
+
+    @regression
+    Examples: Individual Response Reminder letter: <pack code>
+      | pack code   | sample file                  |
+      | P_RL_1IRL2B | sample_1_welsh_HH_unit.csv   |

--- a/acceptance_tests/features/print_reminder.feature
+++ b/acceptance_tests/features/print_reminder.feature
@@ -17,8 +17,24 @@ Feature: Scheduled reminder print and manifest files can be generated and upload
       | pack code     | questionnaire types | sample file                        |
       | P_RL_2RL2B_3a | [02]                | sample_input_wales_census_spec.csv |
 
+  Scenario Outline: Generate print files and log events for scheduled reminder letters
+    Given sample file "<sample file>" is loaded and correct qids <questionnaire types> set
+    When set action rule of type "<pack code>"
+    Then UAC Updated events emitted for the 2 cases with matching treatment codes
+    And correctly formatted "<pack code>" reminder letter print files are created
+    And there is a correct "<pack code>" manifest file for each csv file written
+    And "PRINT_CASE_SELECTED" events are logged against the cases included in the reminder
 
-  Scenario: Generate print files and log events for scheduled questionnaire letters
+    Examples: Reminder letter: <pack code>
+      | pack code   | questionnaire types | sample file                          |
+      | P_RL_1RL1_1 | [01]                | sample_input_england_census_spec.csv |
+
+    @regression
+    Examples: Reminder letter: <pack code>
+      | pack code     | questionnaire types | sample file                        |
+      | P_RL_2RL2B_3a | [02]                | sample_input_wales_census_spec.csv |
+
+  Scenario: Generate print files and log events for scheduled reminder questionnaire letters
     Given sample file "sample_for_reminder_questionnaire.csv" is loaded successfully
     When set action rule of type "P_QU_H2"
     Then 2 UAC Updated events are emitted for the 3 cases with matching treatment codes
@@ -59,6 +75,10 @@ Feature: Scheduled reminder print and manifest files can be generated and upload
     Examples: Reminder contact letter: <pack code>
       | pack code   | lsoa list                                 | sample file                                        |
       | P_RL_1RL1A  | [E01014540,E01014541]                     | sample_input_england_response_driven_reminders.csv |
+
+    @regression
+    Examples: Reminder contact letter: <pack code>
+      | pack code   | lsoa list                                 | sample file                                        |
       | P_RL_1RL2BA | [E01014669,W01014669]                     | sample_input_wales_census_spec.csv                 |
       | P_RL_2RL1A  | [E01014543,E01014544]                     | sample_input_england_response_driven_reminders.csv |
       | P_RL_2RL2BA | [E01033361,E01015005,W01033361,W01015005] | sample_input_wales_census_spec.csv                 |

--- a/acceptance_tests/features/steps/action_rules.py
+++ b/acceptance_tests/features/steps/action_rules.py
@@ -13,6 +13,15 @@ def setup_print_action_rule_once_case_action_is_drained_spg_military_sfa(context
     build_and_create_action_rule(context, DEFAULT_CLASSIFIERS + "estab_type = 'MILITARY SFA'", action_type)
 
 
+@step('the individual response reminder action rule of type "{action_type}" is set')
+def setup_print_reminder_action_rule_for_hi_cases(context, action_type):
+    region_classifier = {
+        'P_RL_1IRL1': "substring(region, 1, 1) = 'E'",
+        'P_RL_1IRL2B': "substring(region, 1, 1) = 'W'",
+    }
+    build_and_create_action_rule(context, region_classifier[action_type] + " AND case_type = 'HI'", action_type)
+
+
 @step('a FIELD action rule for address type "{address_type}" is set')
 def create_field_action_plan(context, address_type):
     build_and_create_action_rule(context, DEFAULT_CLASSIFIERS + f"address_type = '{address_type}'", 'FIELD')

--- a/acceptance_tests/features/steps/action_rules.py
+++ b/acceptance_tests/features/steps/action_rules.py
@@ -19,7 +19,8 @@ def setup_print_reminder_action_rule_for_hi_cases(context, action_type):
         'P_RL_1IRL1': "substring(region, 1, 1) = 'E'",
         'P_RL_1IRL2B': "substring(region, 1, 1) = 'W'",
     }
-    build_and_create_action_rule(context, region_classifier[action_type] + " AND case_type = 'HI'", action_type)
+    build_and_create_action_rule(context, region_classifier[action_type] +
+                                 " AND case_type = 'HI' AND metadata->>'channel' = 'EQ'", action_type)
 
 
 @step('a FIELD action rule for address type "{address_type}" is set')

--- a/acceptance_tests/features/steps/case_events.py
+++ b/acceptance_tests/features/steps/case_events.py
@@ -1,10 +1,10 @@
-
 import functools
 
 from behave import step
 
-from acceptance_tests.utilities.event_helper import get_extended_case_created_events_for_uacs,\
-    get_and_test_case_and_uac_msgs_are_correct, test_uacs_correct_for_estab_units
+from acceptance_tests.utilities.event_helper import get_extended_case_created_events_for_uacs, \
+    get_and_test_case_and_uac_msgs_are_correct, test_uacs_correct_for_estab_units, get_case_created_events, \
+    get_last_uac_updated_event
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, \
     store_all_uac_updated_msgs_by_collection_exercise_id, store_first_message_in_context
 from acceptance_tests.utilities.test_case_helper import test_helper
@@ -66,3 +66,11 @@ def case_updated_msg_with_metadata_field(context, field, expected_field_value):
                                     functools.partial(store_first_message_in_context,
                                                       context=context))
     test_helper.assertEqual(context.first_message['payload']['metadata'][field], expected_field_value)
+
+
+@step('an EQ individual response HI case created and uac updated event are emitted')
+def gather_eq_ir_case_created_and_uac_updated_events(context):
+    context.case_created_events = get_case_created_events(context, 1)
+    context.reminder_case_ids = [context.case_created_events[0]['payload']['collectionCase']['id']]
+    get_last_uac_updated_event(context)
+    context.reminder_uac_updated_events = [context.last_uac_updated_event]

--- a/acceptance_tests/features/steps/print_file.py
+++ b/acceptance_tests/features/steps/print_file.py
@@ -14,7 +14,8 @@ from acceptance_tests.utilities.print_file_helper import \
     create_expected_csv_lines_for_ce_estab_responses, create_expected_CE_Estab_questionnaire_csv_lines, \
     create_expected_questionnaire_csv_lines, create_expected_Welsh_CE_Estab_questionnaire_csv_line_endings, \
     create_expected_HH_UAC_supplementary_materials_csv, create_expected_csv_lines_for_reminder_survey_launched, \
-    check_print_files_have_all_the_expected_data, create_individual_print_material_csv_line_for_spg_ce
+    check_print_files_have_all_the_expected_data, create_individual_print_material_csv_line_for_spg_ce, \
+    create_expected_individual_reminder_letter_csv_lines
 from acceptance_tests.utilities.sftp_utility import SftpUtility
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -117,6 +118,12 @@ def check_correct_ce_estab_files_on_sftp_server(context, pack_code):
 @then('correctly formatted "{pack_code}" reminder letter print files are created')
 def check_correct_reminder_letter_files_on_sftp_server(context, pack_code):
     expected_csv_lines = create_expected_reminder_letter_csv_lines(context, pack_code)
+    check_print_files_have_all_the_expected_data(context, expected_csv_lines, pack_code)
+
+
+@step('correctly formatted "{pack_code}" individual reminder letter print files are created')
+def check_correct_individual_reminder_letter_files_on_sftp_server(context, pack_code):
+    expected_csv_lines = create_expected_individual_reminder_letter_csv_lines(context, pack_code)
     check_print_files_have_all_the_expected_data(context, expected_csv_lines, pack_code)
 
 

--- a/acceptance_tests/features/steps/sample.py
+++ b/acceptance_tests/features/steps/sample.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from behave import step
 
 from acceptance_tests.utilities.action_helper import poll_until_sample_is_ingested_to_action
-from acceptance_tests.utilities.event_helper import get_and_check_case_created_messages, \
+from acceptance_tests.utilities.event_helper import get_and_check_sample_load_case_created_messages, \
     get_and_check_uac_updated_messages, get_and_test_case_and_uac_msgs_are_correct
 from acceptance_tests.utilities.sample_load_helper import load_sample_file_helper
 
@@ -18,7 +18,7 @@ def load_sample_file_step(context, sample_file_name):
 def load_sample_file_successfully_step(context, sample_file_name):
     load_sample_file_helper(context, sample_file_name)
 
-    get_and_check_case_created_messages(context)
+    get_and_check_sample_load_case_created_messages(context)
     get_and_check_uac_updated_messages(context)
 
     poll_until_sample_is_ingested_to_action(context)
@@ -45,7 +45,7 @@ def load_sample_file_successfully_after(context, wait, sample_file_name):
     context.address_delta_load_time = datetime.utcnow()
 
     load_sample_file_helper(context, sample_file_name)
-    get_and_check_case_created_messages(context)
+    get_and_check_sample_load_case_created_messages(context)
     get_and_check_uac_updated_messages(context)
 
     poll_until_sample_is_ingested_to_action(context, after_date_time=context.address_delta_load_time)

--- a/acceptance_tests/utilities/mappings.py
+++ b/acceptance_tests/utilities/mappings.py
@@ -180,6 +180,8 @@ PACK_CODE_TO_SFTP_DIRECTORY = {
     "P_RL_1RL2BA": Config.SFTP_PPO_DIRECTORY,
     "P_RL_2RL1A": Config.SFTP_PPO_DIRECTORY,
     "P_RL_2RL2BA": Config.SFTP_PPO_DIRECTORY,
+    "P_RL_1IRL1": Config.SFTP_PPO_DIRECTORY,
+    "P_RL_1IRL2B": Config.SFTP_PPO_DIRECTORY,
     "D_CE1A_ICLCR1": Config.SFTP_PPO_DIRECTORY,
     "D_CE1A_ICLCR2B": Config.SFTP_PPO_DIRECTORY,
     "D_ICA_ICLR1": Config.SFTP_PPO_DIRECTORY,
@@ -330,6 +332,8 @@ PACK_CODE_TO_DATASET = {
     "P_RL_1RL2BA": PPD1_2_DATASET,
     "P_RL_2RL1A": PPD1_2_DATASET,
     "P_RL_2RL2BA": PPD1_2_DATASET,
+    "P_RL_1IRL1": PPD1_2_DATASET,
+    "P_RL_1IRL2B": PPD1_2_DATASET,
     "D_CE1A_ICLCR1": PPD1_7_DATASET,
     "D_CE1A_ICLCR2B": PPD1_7_DATASET,
     "D_ICA_ICLR1": PPD1_7_DATASET,
@@ -493,6 +497,8 @@ PACK_CODE_TO_DESCRIPTION = {
     "P_RL_2RL1A": '2nd Reminder, Letter - for England addresses for survey launched but not completed',
     "P_RL_2RL2BA": '2nd Reminder, Letter - for Wales addresses (bilingual Welsh and English) for survey'
                    ' launched but not completed',
+    "P_RL_1IRL1": 'Individual response reminder letter for England addresses',
+    "P_RL_1IRL2B": 'Individual response reminder letter for Wales addresses',
 }
 
 QUESTIONNAIRE_TYPE_TO_FORM_TYPE = {

--- a/acceptance_tests/utilities/mappings.py
+++ b/acceptance_tests/utilities/mappings.py
@@ -497,8 +497,8 @@ PACK_CODE_TO_DESCRIPTION = {
     "P_RL_2RL1A": '2nd Reminder, Letter - for England addresses for survey launched but not completed',
     "P_RL_2RL2BA": '2nd Reminder, Letter - for Wales addresses (bilingual Welsh and English) for survey'
                    ' launched but not completed',
-    "P_RL_1IRL1": 'Individual response reminder letter for England addresses',
-    "P_RL_1IRL2B": 'Individual response reminder letter for Wales addresses',
+    "P_RL_1IRL1": 'Individual reminder letter - England',
+    "P_RL_1IRL2B": 'Individual reminder letter - Bilingual',
 }
 
 QUESTIONNAIRE_TYPE_TO_FORM_TYPE = {

--- a/acceptance_tests/utilities/print_file_helper.py
+++ b/acceptance_tests/utilities/print_file_helper.py
@@ -160,10 +160,6 @@ def create_expected_individual_reminder_letter_csv_lines(context, pack_code):
     expected_reminder_case_created_events = (case for case in context.case_created_events
                                              if case['payload']['collectionCase']['id'] in context.reminder_case_ids)
 
-    for uac in context.reminder_uac_updated_events:
-        expected_data[uac['payload']['uac']['caseId']]['uac'] = uac['payload']['uac']['uac']
-        expected_data[uac['payload']['uac']['caseId']]['questionnaire_id'] = uac['payload']['uac']['questionnaireId']
-
     for case in expected_reminder_case_created_events:
         expected_data = _add_expected_individual_case_data(case, expected_data)
 

--- a/acceptance_tests/utilities/print_file_helper.py
+++ b/acceptance_tests/utilities/print_file_helper.py
@@ -154,6 +154,25 @@ def create_expected_reminder_letter_csv_lines(context, pack_code):
     ]
 
 
+def create_expected_individual_reminder_letter_csv_lines(context, pack_code):
+    expected_data = defaultdict(dict)
+
+    expected_reminder_case_created_events = (case for case in context.case_created_events
+                                             if case['payload']['collectionCase']['id'] in context.reminder_case_ids)
+
+    for uac in context.reminder_uac_updated_events:
+        expected_data[uac['payload']['uac']['caseId']]['uac'] = uac['payload']['uac']['uac']
+        expected_data[uac['payload']['uac']['caseId']]['questionnaire_id'] = uac['payload']['uac']['questionnaireId']
+
+    for case in expected_reminder_case_created_events:
+        expected_data = _add_expected_individual_case_data(case, expected_data)
+
+    return [
+        _create_expected_individual_reminder_csv_line(case, pack_code)
+        for case in expected_data.values()
+    ]
+
+
 def create_expected_reminder_questionnaire_csv_lines(context, pack_code):
     expected_data = defaultdict(dict)
 
@@ -219,6 +238,17 @@ def _add_expected_questionnaire_case_data(message, expected_data):
     return expected_data
 
 
+def _add_expected_individual_case_data(message, expected_data):
+    case_id = message['payload']['collectionCase']['id']
+
+    collection_case = message['payload']['collectionCase']
+    expected_data[case_id]['case_ref'] = collection_case['caseRef']
+
+    _populate_expected_address(case_id, expected_data, message)
+
+    return expected_data
+
+
 def _populate_expected_address(case_id, expected_data, message):
     address = message['payload']['collectionCase']['address']
     expected_data[case_id]['address_line_1'] = address['addressLine1']
@@ -244,6 +274,23 @@ def _create_expected_csv_line(case, prefix):
         f'{case["organization_name"]}|'
         f'{case["coordinator_id"]}|'
         f'{case["officer_id"]}'
+    )
+
+
+def _create_expected_individual_reminder_csv_line(case, prefix):
+    return (
+        '|'
+        f'{case["case_ref"]}|'
+        '|||'
+        f'{case["address_line_1"]}|'
+        f'{case["address_line_2"]}|'
+        f'{case["address_line_3"]}|'
+        f'{case["town_name"]}|'
+        f'{case["postcode"]}|'
+        f'{prefix}|'
+        '|'
+        f'{case["organization_name"]}|'
+        '|'
     )
 
 


### PR DESCRIPTION
# Motivation and Context
We're sending reminder letters to any and every unreceipted HI case created via EQ

# What has changed
* A scenarios for individual reminder print files
* Split initial contact and reminder print files into separate features (print_file.feature was getting massive)

# How to test?
Build and run linked branches

# Links
https://trello.com/c/Rc8d1RmE/983-reminders-individual-response-8
https://github.com/ONSdigital/census-rm-case-processor/pull/173
https://github.com/ONSdigital/census-rm-case-api/pull/87
https://github.com/ONSdigital/census-rm-action-scheduler/pull/98
https://github.com/ONSdigital/census-rm-action-processor/pull/6
https://github.com/ONSdigital/census-rm-action-worker/pull/39
https://github.com/ONSdigital/census-rm-print-file-service/pull/51