### PR TITLE
Stop logging skipped tests by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ run_regression_tests:
 	SFTP_KEY_FILENAME=dummy_sftp_private_key PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run behave acceptance_tests/features --logging-level WARN --format=progress2
 
 run_smoke_tests:
-	SFTP_KEY_FILENAME=dummy_sftp_private_key PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run behave acceptance_tests/features --logging-level WARN --tags=@smoke --format=progress2
+	SFTP_KEY_FILENAME=dummy_sftp_private_key PUBSUB_EMULATOR_HOST=localhost:8538 pipenv run behave acceptance_tests/features --logging-level WARN --tags=@smoke --no-skipped
 
 build:
 	docker build -t eu.gcr.io/census-rm-ci/rm/census-rm-acceptance-tests .

--- a/run.py
+++ b/run.py
@@ -19,6 +19,7 @@ def parse_arguments():
     parser.add_argument('--format', '-f', help='Behave format', default=DEFAULT_BEHAVE_FORMAT)
     parser.add_argument('--feature_directory', '-fd', help='Feature directory', default=DEFAULT_FEATURE_DIRECTORY)
     parser.add_argument('--tags', '-t', help='Tags', default=DEFAULT_TAGS)
+    parser.add_argument('--show_skipped', help='Show skipped tests', action='store_true')
 
     return parser.parse_args()
 
@@ -32,7 +33,8 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     tags_arg = f'--tags {args.tags}' if args.tags else ''
-    args = f'--logging-level {args.log_level} --format {args.format} {args.feature_directory} {tags_arg}'
+    show_skipped = '--show-skipped' if args.show_skipped else '--no-skipped'
+    args = f'--logging-level {args.log_level} --format {args.format} {args.feature_directory} {tags_arg} {show_skipped}'
     return behave_executable.main(args)
 
 

--- a/tasks/kubectl-run-acceptance-tests.yml
+++ b/tasks/kubectl-run-acceptance-tests.yml
@@ -39,7 +39,7 @@ run:
       kubectl wait --for=condition=Ready pod/acceptance-tests --timeout=200s
 
       kubectl exec -it acceptance-tests -- /bin/bash -c \
-      "sleep 2; behave acceptance_tests/features --tags=~@local-docker --tags=~@regression"
+      "sleep 2; behave acceptance_tests/features --tags=~@local-docker --tags=~@regression --no-skipped"
 
       kubectl delete pod acceptance-tests || true
 


### PR DESCRIPTION
# Motivation and Context
The hundreds of skipped regression tests are unwanted noise in the AT logs.

# What has changed
* Use --no-skipped option to avoid logging skipped tests

# How to test?
Run `make test`, you should no longer get thousands of log lines of skipped tests 
 
# Links
https://trello.com/c/WHTef3Jy/1181-stop-logging-all-the-skipped-regression-tests-in-the-at-runs