### PR TITLE
Request UAC via SMS (HH, Ind & CE1)

### DIFF
--- a/acceptance_tests/features/eq_individual_response.feature
+++ b/acceptance_tests/features/eq_individual_response.feature
@@ -4,21 +4,21 @@ Feature: Request individual response via EQ
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When an individual SMS UAC fulfilment request "<fulfilment code>" message is sent by EQ
     Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
-    And notify api was called with SMS template "<SMS template>"
+    And notify api was called with SMS template for fulfilment code "<fulfilment code>"
     And a UAC updated message with "<questionnaire type>" questionnaire type is emitted for the individual case
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
     And the individual case has these events logged [RM_UAC_CREATED]
 
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template |
-      | UACIT1          | 21                 | UACIT1       |
+      | fulfilment code | questionnaire type |
+      | UACIT1          | 21                 |
 
     @regression
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template |
-      | UACIT2          | 22                 | UACIT2       |
-      | UACIT2W         | 23                 | UACIT2W      |
-      | UACIT4          | 24                 | UACIT4       |
+      | fulfilment code | questionnaire type |
+      | UACIT2          | 22                 |
+      | UACIT2W         | 23                 |
+      | UACIT4          | 24                 |
 
   Scenario Outline: Individual UAC print requests via EQ
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully

--- a/acceptance_tests/features/eq_individual_response.feature
+++ b/acceptance_tests/features/eq_individual_response.feature
@@ -10,15 +10,15 @@ Feature: Request individual response via EQ
     And the individual case has these events logged [RM_UAC_CREATED]
 
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template       |
-      | UACIT1          | 21                 | individual English |
+      | fulfilment code | questionnaire type | SMS template |
+      | UACIT1          | 21                 | UACIT1       |
 
     @regression
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template                 |
-      | UACIT2          | 22                 | individual Welsh and English |
-      | UACIT2W         | 23                 | individual Welsh             |
-      | UACIT4          | 24                 | individual Northern Ireland  |
+      | fulfilment code | questionnaire type | SMS template |
+      | UACIT2          | 22                 | UACIT2       |
+      | UACIT2W         | 23                 | UACIT2W      |
+      | UACIT4          | 24                 | UACIT4       |
 
   Scenario Outline: Individual UAC print requests via EQ
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -305,3 +305,10 @@ Feature: Handle fulfilment request events
     And a UAC updated message with "21" questionnaire type is emitted
     And print file and manifest files are created for pack code "P_OR_I1" with individual contact details
     Then the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED,PRINT_CASE_SELECTED]
+
+  Scenario: CE and SPG UAC SMS Individual fulfilments without Individual Case ID
+    Given sample file "sample_1_english_SPG_estab.csv" is loaded successfully
+    When an individual UAC SMS fulfilment request "UACIT1" is received by RM
+    And a UAC updated message with "21" questionnaire type is emitted
+    Then notify api was called with SMS template "individual English"
+    And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED]

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -1,6 +1,6 @@
 Feature: Handle fulfilment request events
 
-  Scenario Outline: Household UAC SMS requests
+  Scenario Outline: Household and CE UAC SMS requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
     Then notify api was called with SMS template "<SMS template>"
@@ -12,12 +12,22 @@ Feature: Handle fulfilment request events
       | fulfilment code | questionnaire type | SMS template      |
       | UACHHT1         | 01                 | household English |
 
+    Examples: CE UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | SMS template |
+      | UACCET1         | 31                 | ce English   |
+
     @regression
     Examples: Household UAC fulfilment codes: <fulfilment code>
       | fulfilment code | questionnaire type | SMS template                |
       | UACHHT2         | 02                 | household Welsh and English |
       | UACHHT2W        | 03                 | household Welsh             |
       | UACHHT4         | 04                 | household Northern Ireland  |
+
+    @regression
+    Examples: CE UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | SMS template         |
+      | UACCET2         | 32                 | ce Welsh and English |
+      | UACCET2W        | 33                 | ce Welsh             |
 
   Scenario Outline: Individual UAC SMS requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -306,7 +306,7 @@ Feature: Handle fulfilment request events
     And print file and manifest files are created for pack code "P_OR_I1" with individual contact details
     Then the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED,PRINT_CASE_SELECTED]
 
-  Scenario: CE and SPG UAC SMS Individual fulfilments without Individual Case ID
+  Scenario: Individual UAC SMS fulfilments without Individual Case ID
     Given sample file "sample_1_english_SPG_estab.csv" is loaded successfully
     When an individual UAC SMS fulfilment request "UACIT1" is received by RM
     And a UAC updated message with "21" questionnaire type is emitted

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -3,59 +3,59 @@ Feature: Handle fulfilment request events
   Scenario Outline: Household UAC SMS requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
-    Then notify api was called with SMS template "<SMS template>"
+    Then notify api was called with SMS template for fulfilment code "<fulfilment code>"
     And a UAC updated message with "<questionnaire type>" questionnaire type is emitted
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED]
 
     @smoke
     Examples: Household UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template |
-      | UACHHT1         | 01                 | UACHHT1      |
+      | fulfilment code | questionnaire type |
+      | UACHHT1         | 01                 |
 
     @regression
     Examples: Household UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template |
-      | UACHHT2         | 02                 | UACHHT2      |
-      | UACHHT2W        | 03                 | UACHHT2W     |
-      | UACHHT4         | 04                 | UACHHT4      |
+      | fulfilment code | questionnaire type |
+      | UACHHT2         | 02                 |
+      | UACHHT2W        | 03                 |
+      | UACHHT4         | 04                 |
 
   Scenario Outline: CE UAC SMS requests
     Given sample file "sample_1_english_CE_estab.csv" is loaded successfully
     When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
-    Then notify api was called with SMS template "<SMS template>"
+    Then notify api was called with SMS template for fulfilment code "<fulfilment code>"
     And a UAC updated message with "<questionnaire type>" questionnaire type is emitted
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED]
 
     @smoke
     Examples: CE UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template |
-      | UACCET1         | 31                 | UACCET1      |
+      | fulfilment code | questionnaire type |
+      | UACCET1         | 31                 |
 
     @regression
     Examples: CE UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template |
-      | UACCET2         | 32                 | UACCET2      |
-      | UACCET2W        | 33                 | UACCET2W     |
+      | fulfilment code | questionnaire type |
+      | UACCET2         | 32                 |
+      | UACCET2W        | 33                 |
 
   Scenario Outline: Individual UAC SMS requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
     Then a new individual child case for the fulfilment is emitted to RH and Action Scheduler
-    And notify api was called with SMS template "<SMS template>"
+    And notify api was called with SMS template for fulfilment code "<fulfilment code>"
     And a UAC updated message with "<questionnaire type>" questionnaire type is emitted for the individual case
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED]
     And the individual case has these events logged [RM_UAC_CREATED]
 
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template |
-      | UACIT1          | 21                 | UACIT1       |
+      | fulfilment code | questionnaire type |
+      | UACIT1          | 21                 |
 
     @regression
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template |
-      | UACIT2          | 22                 | UACIT2       |
-      | UACIT2W         | 23                 | UACIT2W      |
-      | UACIT4          | 24                 | UACIT4       |
+      | fulfilment code | questionnaire type |
+      | UACIT2          | 22                 |
+      | UACIT2W         | 23                 |
+      | UACIT4          | 24                 |
 
   Scenario Outline: Generate print files and log events for questionnaire fulfilment requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
@@ -318,5 +318,5 @@ Feature: Handle fulfilment request events
     Given sample file "sample_1_english_SPG_estab.csv" is loaded successfully
     When an individual UAC SMS fulfilment request "UACIT1" is received by RM for a CE/SPG case
     And a UAC updated message with "21" questionnaire type is emitted
-    Then notify api was called with SMS template "UACIT1"
+    Then notify api was called with SMS template for fulfilment code "UACIT1"
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED]

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -1,6 +1,6 @@
 Feature: Handle fulfilment request events
 
-  Scenario Outline: Household and CE UAC SMS requests
+  Scenario Outline: Household UAC SMS requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
     Then notify api was called with SMS template "<SMS template>"
@@ -9,25 +9,33 @@ Feature: Handle fulfilment request events
 
     @smoke
     Examples: Household UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template      |
-      | UACHHT1         | 01                 | household English |
-
-    Examples: CE UAC fulfilment codes: <fulfilment code>
       | fulfilment code | questionnaire type | SMS template |
-      | UACCET1         | 31                 | ce English   |
+      | UACHHT1         | 01                 | UACHHT1      |
 
     @regression
     Examples: Household UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template                |
-      | UACHHT2         | 02                 | household Welsh and English |
-      | UACHHT2W        | 03                 | household Welsh             |
-      | UACHHT4         | 04                 | household Northern Ireland  |
+      | fulfilment code | questionnaire type | SMS template |
+      | UACHHT2         | 02                 | UACHHT2      |
+      | UACHHT2W        | 03                 | UACHHT2W     |
+      | UACHHT4         | 04                 | UACHHT4      |
+
+  Scenario Outline: CE UAC SMS requests
+    Given sample file "sample_1_english_CE_estab.csv" is loaded successfully
+    When a UAC fulfilment request "<fulfilment code>" message for a created case is sent
+    Then notify api was called with SMS template "<SMS template>"
+    And a UAC updated message with "<questionnaire type>" questionnaire type is emitted
+    And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED]
+
+    @smoke
+    Examples: CE UAC fulfilment codes: <fulfilment code>
+      | fulfilment code | questionnaire type | SMS template |
+      | UACCET1         | 31                 | UACCET1      |
 
     @regression
     Examples: CE UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template         |
-      | UACCET2         | 32                 | ce Welsh and English |
-      | UACCET2W        | 33                 | ce Welsh             |
+      | fulfilment code | questionnaire type | SMS template |
+      | UACCET2         | 32                 | UACCET2      |
+      | UACCET2W        | 33                 | UACCET2W     |
 
   Scenario Outline: Individual UAC SMS requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
@@ -39,15 +47,15 @@ Feature: Handle fulfilment request events
     And the individual case has these events logged [RM_UAC_CREATED]
 
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template       |
-      | UACIT1          | 21                 | individual English |
+      | fulfilment code | questionnaire type | SMS template |
+      | UACIT1          | 21                 | UACIT1       |
 
     @regression
     Examples: Individual UAC fulfilment codes: <fulfilment code>
-      | fulfilment code | questionnaire type | SMS template                 |
-      | UACIT2          | 22                 | individual Welsh and English |
-      | UACIT2W         | 23                 | individual Welsh             |
-      | UACIT4          | 24                 | individual Northern Ireland  |
+      | fulfilment code | questionnaire type | SMS template |
+      | UACIT2          | 22                 | UACIT2       |
+      | UACIT2W         | 23                 | UACIT2W      |
+      | UACIT4          | 24                 | UACIT4       |
 
   Scenario Outline: Generate print files and log events for questionnaire fulfilment requests
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
@@ -310,5 +318,5 @@ Feature: Handle fulfilment request events
     Given sample file "sample_1_english_SPG_estab.csv" is loaded successfully
     When an individual UAC SMS fulfilment request "UACIT1" is received by RM for a CE/SPG case
     And a UAC updated message with "21" questionnaire type is emitted
-    Then notify api was called with SMS template "individual English"
+    Then notify api was called with SMS template "UACIT1"
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED]

--- a/acceptance_tests/features/fulfilment.feature
+++ b/acceptance_tests/features/fulfilment.feature
@@ -306,9 +306,9 @@ Feature: Handle fulfilment request events
     And print file and manifest files are created for pack code "P_OR_I1" with individual contact details
     Then the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED,PRINT_CASE_SELECTED]
 
-  Scenario: Individual UAC SMS fulfilments without Individual Case ID
+  Scenario: Individual UAC SMS fulfilments for a CE/SPG case
     Given sample file "sample_1_english_SPG_estab.csv" is loaded successfully
-    When an individual UAC SMS fulfilment request "UACIT1" is received by RM
+    When an individual UAC SMS fulfilment request "UACIT1" is received by RM for a CE/SPG case
     And a UAC updated message with "21" questionnaire type is emitted
     Then notify api was called with SMS template "individual English"
     And the fulfilment request case has these events logged [SAMPLE_LOADED,FULFILMENT_REQUESTED,RM_UAC_CREATED]

--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -187,6 +187,58 @@ def create_individual_print_fulfilment_message(context, fulfilment_code):
             routing_key=Config.RABBITMQ_FULFILMENT_REQUESTED_ROUTING_KEY)
 
 
+@step('an individual UAC SMS fulfilment request "{fulfilment_code}" is received by RM')
+def create_individual_uac_sms_fulfilment_message_without_ind_case_id(context, fulfilment_code):
+    requests.get(f'{Config.NOTIFY_STUB_SERVICE}/reset')
+
+    context.first_case = get_first_case(context)
+    context.fulfilment_requested_case_id = context.uac_created_events[0]['payload']['uac']['caseId']
+    message = json.dumps(
+        {
+            "event": {
+                "type": "FULFILMENT_REQUESTED",
+                "source": "CONTACT_CENTRE_API",
+                "channel": "CC",
+                "dateTime": "2019-07-07T22:37:11.988+0000",
+                "transactionId": "d2541acb-230a-4ade-8123-eee2310c9143"
+            },
+            "payload": {
+                "fulfilmentRequest": {
+                    "fulfilmentCode": fulfilment_code,
+                    "caseId": context.fulfilment_requested_case_id,
+                    "individualCaseId": None,
+                    "address": {
+                        "addressLine1": "1 main street",
+                        "addressLine2": "upper upperingham",
+                        "addressLine3": "",
+                        "townName": "upton",
+                        "postcode": "UP103UP",
+                        "region": "E",
+                        "latitude": "50.863849",
+                        "longitude": "-1.229710",
+                        "uprn": "XXXXXXXXXXXXX",
+                        "addressType": "CE",
+                        "estabType": "XXX"
+                    },
+                    "contact": {
+                        "title": "Ms",
+                        "forename": "jo",
+                        "surname": "smith",
+                        "email": "me@example.com",
+                        "telNo": "01234567"
+                    }
+                }
+            }
+        }
+    )
+
+    with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
+        rabbit.publish_message(
+            message=message,
+            content_type='application/json',
+            routing_key=Config.RABBITMQ_FULFILMENT_REQUESTED_ROUTING_KEY)
+
+
 @step("a fulfilment request event is logged")
 def check_case_events_logged(context):
     response = requests.get(f"{Config.CASE_API_CASE_URL}{context.fulfilment_requested_case_id}",

--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -252,7 +252,7 @@ def check_case_events_logged(context):
 
 @step('notify api was called with SMS template "{expected_template}"')
 def check_notify_api_call(context, expected_template: str):
-    _check_notify_api_called_with_correct_template_id(NOTIFY_TEMPLATE['_'.join(expected_template.lower().split())])
+    _check_notify_api_called_with_correct_template_id(NOTIFY_TEMPLATE['_'.join(expected_template.split())])
 
 
 @retry(stop_max_attempt_number=10, wait_fixed=1000)

--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -250,9 +250,9 @@ def check_case_events_logged(context):
     test_helper.fail('Did not find fulfilment request event')
 
 
-@step('notify api was called with SMS template "{expected_template}"')
-def check_notify_api_call(context, expected_template: str):
-    _check_notify_api_called_with_correct_template_id(NOTIFY_TEMPLATE['_'.join(expected_template.split())])
+@step('notify api was called with SMS template for fulfilment code "{fulfilment_code}"')
+def check_notify_api_call(context, fulfilment_code: str):
+    _check_notify_api_called_with_correct_template_id(NOTIFY_TEMPLATE[fulfilment_code])
 
 
 @retry(stop_max_attempt_number=10, wait_fixed=1000)

--- a/acceptance_tests/features/steps/fulfilment.py
+++ b/acceptance_tests/features/steps/fulfilment.py
@@ -187,7 +187,7 @@ def create_individual_print_fulfilment_message(context, fulfilment_code):
             routing_key=Config.RABBITMQ_FULFILMENT_REQUESTED_ROUTING_KEY)
 
 
-@step('an individual UAC SMS fulfilment request "{fulfilment_code}" is received by RM')
+@step('an individual UAC SMS fulfilment request "{fulfilment_code}" is received by RM for a CE/SPG case')
 def create_individual_uac_sms_fulfilment_message_without_ind_case_id(context, fulfilment_code):
     requests.get(f'{Config.NOTIFY_STUB_SERVICE}/reset')
 

--- a/acceptance_tests/utilities/mappings.py
+++ b/acceptance_tests/utilities/mappings.py
@@ -530,19 +530,19 @@ QUESTIONNAIRE_TYPE_TO_FORM_TYPE = {
 
 NOTIFY_TEMPLATE = {
     # Household
-    "household_english": "ce1e545e-f50f-455b-a394-88b49a36fa0c",
-    "household_welsh_and_english": "2375c493-359d-4712-938e-bf97a641f18f",
-    "household_welsh": "67dc02ff-a667-4b21-8e4e-61dd28936b8c",
-    "household_northern_ireland": "5d985237-b446-492a-bd0a-f7368265282c",
+    "UACHHT1": "ce1e545e-f50f-455b-a394-88b49a36fa0c",
+    "UACHHT2": "2375c493-359d-4712-938e-bf97a641f18f",
+    "UACHHT2W": "67dc02ff-a667-4b21-8e4e-61dd28936b8c",
+    "UACHHT4": "5d985237-b446-492a-bd0a-f7368265282c",
 
     # Individual
-    "individual_english": "b7ec0cde-b55b-460a-a78a-cb80767acdca",
-    "individual_welsh_and_english": "f6de09f2-4d4c-4f62-82e3-b1a24e0cf910",
-    "individual_welsh": "b2db05f0-d7d1-4b88-b3de-658495bd8a47",
-    "individual_northern_ireland": "d490af7d-300a-4eb8-a961-cb4de54332ee",
+    "UACIT1": "b7ec0cde-b55b-460a-a78a-cb80767acdca",
+    "UACIT2": "f6de09f2-4d4c-4f62-82e3-b1a24e0cf910",
+    "UACIT2W": "b2db05f0-d7d1-4b88-b3de-658495bd8a47",
+    "UACIT4": "d490af7d-300a-4eb8-a961-cb4de54332ee",
 
     # CE
-    "ce_english": "21f22f8d-2642-444e-9d13-a54b87647a93",
-    "ce_welsh_and_english": "b2b9e650-cb22-49d7-b5da-95169e13ea12",
-    "ce_welsh": "2c12a125-4035-4b81-9988-204e02e759a5"
+    "UACCET1": "21f22f8d-2642-444e-9d13-a54b87647a93",
+    "UACCET2": "b2b9e650-cb22-49d7-b5da-95169e13ea12",
+    "UACCET2W": "2c12a125-4035-4b81-9988-204e02e759a5"
 }

--- a/acceptance_tests/utilities/mappings.py
+++ b/acceptance_tests/utilities/mappings.py
@@ -530,14 +530,19 @@ QUESTIONNAIRE_TYPE_TO_FORM_TYPE = {
 
 NOTIFY_TEMPLATE = {
     # Household
-    "household_english": "21447bc2-e7c7-41ba-8c5e-7a5893068525",
-    "household_welsh_and_english": "23f96daf-9674-4087-acfc-ffe98a52cf16",
-    "household_welsh": "ef045f43-ffa8-4047-b8e2-65bfbce0f026",
-    "household_northern_ireland": "1ccd02a4-9b90-4234-ab7a-9215cb498f14",
+    "household_english": "ce1e545e-f50f-455b-a394-88b49a36fa0c",
+    "household_welsh_and_english": "2375c493-359d-4712-938e-bf97a641f18f",
+    "household_welsh": "67dc02ff-a667-4b21-8e4e-61dd28936b8c",
+    "household_northern_ireland": "5d985237-b446-492a-bd0a-f7368265282c",
 
-    # Individual (same as household?)
-    "individual_english": "21447bc2-e7c7-41ba-8c5e-7a5893068525",
-    "individual_welsh_and_english": "23f96daf-9674-4087-acfc-ffe98a52cf16",
-    "individual_welsh": "ef045f43-ffa8-4047-b8e2-65bfbce0f026",
-    "individual_northern_ireland": "1ccd02a4-9b90-4234-ab7a-9215cb498f14",
+    # Individual
+    "individual_english": "b7ec0cde-b55b-460a-a78a-cb80767acdca",
+    "individual_welsh_and_english": "f6de09f2-4d4c-4f62-82e3-b1a24e0cf910",
+    "individual_welsh": "b2db05f0-d7d1-4b88-b3de-658495bd8a47",
+    "individual_northern_ireland": "d490af7d-300a-4eb8-a961-cb4de54332ee",
+
+    # CE
+    "ce_english": "21f22f8d-2642-444e-9d13-a54b87647a93",
+    "ce_welsh_and_english": "b2b9e650-cb22-49d7-b5da-95169e13ea12",
+    "ce_welsh": "2c12a125-4035-4b81-9988-204e02e759a5"
 }


### PR DESCRIPTION
# Motivation and Context
New CE UAC fulfilment codes and new treatment ID sender and receiver codes need including 

# What has changed
New CE UAC fulfilment codes included in existing test
Updated notify template IDs

# How to test?
Build repos on card and run the ATs

# Links
https://trello.com/c/0zPdVGFQ/941-request-uac-via-sms-hh-ind-ce1-5
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=UAC+by+SMS+Fulfilment+2021
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?spaceKey=SDC&title=RM+Product+Library
