### PR TITLE
rename tag to be accurate

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -155,7 +155,7 @@ Feature: Address updates
       | E             | CE           | N            | 24                 |
       | E             | SPG          | N            | 24                 |
 
-  @new_aims_topic_and_subscription
+  @purge_aims_topic
   Scenario: New address event received without sourceCaseId and without UPRN
     When a NEW_ADDRESS_REPORTED event is sent from "FIELD" without sourceCaseId or UPRN
     Then a NEW_ADDRESS_ENHANCED event is sent to aims

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -40,7 +40,7 @@ def before_tag(context, tag):
         # e.g where skeleton cases are used
         context.action_plan_id = Config.CENSUS_ACTION_PLAN_ID
         context.collection_exercise_id = Config.CENSUS_COLLECTION_EXERCISE_ID
-    if tag == 'new_aims_topic_and_subscription':
+    if tag == 'purge_aims_topic':
         purge_aims_new_address_topic()
 
 

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -44,6 +44,6 @@ def purge_aims_new_address_topic():
     if ack_ids:
         subscriber.acknowledge(subscription_path, ack_ids)
 
-    # It's possible (though unlikely) that they could be > max_messages on the topic so keep deleting til
+    # It's possible (though unlikely) that they could be > max_messages on the topic so keep deleting till empty
     if len(response.received_messages) == max_messages:
         purge_aims_new_address_topic()


### PR DESCRIPTION
# Motivation and Context
Make the tests a teeny bit better

# What has changed
Old tag name new_aims_topic_and_subscription was inaccurate, renamed to purge_aims_topic.

# How to test?
Test with master