### PR TITLE
add missing double quotes in step def

### DIFF
--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -226,7 +226,7 @@ def new_address_reported_event_with_minimal_fields(context, sender):
             routing_key=Config.RABBITMQ_ADDRESS_ROUTING_KEY)
 
 
-@step('a NEW_ADDRESS_REPORTED event with no FieldCoordinatorId with address type "{address_type} is sent from'
+@step('a NEW_ADDRESS_REPORTED event with no FieldCoordinatorId with address type "{address_type}" is sent from'
       ' "{sender}"')
 @step('a NEW_ADDRESS_REPORTED event with address type "{address_type}" is sent from "{sender}" and the case is created')
 def new_address_reported_event_for_address_type(context, address_type, sender):


### PR DESCRIPTION
# Motivation and Context
Noted that new test was missing " in the step defs, makes case type look weird

# What has changed
Added a "

# How to test?
Test should now set up new case correctly
