### PR TITLE
Add extra logging and purging of AIMs pubsub messages

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -65,6 +65,9 @@ def before_tag(context, tag):
     if tag == 'purge_aims_topic':
         purge_aims_new_address_topic()
 
+        # Temporary extra purge call to help debugging
+        purge_aims_new_address_topic()
+
 
 def after_tag(_, tag):
     if tag == "clear_for_bad_messages":

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -6,7 +6,8 @@ from behave import step
 
 from acceptance_tests.features.steps.receipt import _get_emitted_case
 from acceptance_tests.utilities.event_helper import check_case_created_message_is_emitted
-from acceptance_tests.utilities.pubsub_helper import synchronous_consume_of_aims_pubsub_topic
+from acceptance_tests.utilities.pubsub_helper import synchronous_consume_of_aims_pubsub_topic, \
+    purge_aims_new_address_topic
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue
 from acceptance_tests.utilities.test_case_helper import test_helper
@@ -604,6 +605,11 @@ def new_address_sent_to_aims(context):
 
     actual_case = context.aims_new_address_message['payload']['newAddress']['collectionCase']
     actual_address = actual_case['address']
+
+    # Temporary extra purge for debug logging
+    if actual_case['id'] != context.case_id:
+        purge_aims_new_address_topic()
+
     test_helper.assertEqual(actual_case['id'], context.case_id)
     test_helper.assertEqual(actual_address['uprn'], expected_dummy_uprn)
     test_helper.assertEqual(actual_case['caseType'], 'SPG')

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -39,6 +39,12 @@ def purge_aims_new_address_topic():
                                                      Config.AIMS_NEW_ADDRESS_SUBSCRIPTION)
     response = subscriber.pull(subscription_path, max_messages=max_messages, timeout=5)
 
+    # Temporary extra debug logging
+    if response.received_messages:
+        print('Messages purged from AIMs new address topic:')
+        for message in response.received_messages:
+            print(message.ack_id, message.message.data)
+
     ack_ids = [message.ack_id for message in response.received_messages]
 
     if ack_ids:


### PR DESCRIPTION
# Motivation and Context
A scenario failed a couple of times and I can't chase down why, extra purging and logging of the pubsub messages might help.

# What has changed
* log out purged pubsub messages
* moar purging

# How to test?
Check the code

# Links
https://trello.com/c/hKGx5se1/1291-failing-at