### PR TITLE
Use subscriber seek method to purge pubsub where available

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -155,7 +155,7 @@ Feature: Address updates
       | E             | CE           | N            | 24                 |
       | E             | SPG          | N            | 24                 |
 
-  @purge_aims_topic
+  @purge_aims_subscription
   Scenario: New address event received without sourceCaseId and without UPRN
     When a NEW_ADDRESS_REPORTED event is sent from "FIELD" without sourceCaseId or UPRN
     Then a NEW_ADDRESS_ENHANCED event is sent to aims

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -62,7 +62,7 @@ def before_tag(context, tag):
         # e.g where skeleton cases are used
         context.action_plan_id = Config.CENSUS_ACTION_PLAN_ID
         context.collection_exercise_id = Config.CENSUS_COLLECTION_EXERCISE_ID
-    if tag == 'purge_aims_topic':
+    if tag == 'purge_aims_subscription':
         purge_aims_new_address_subscription()
 
         # Temporary extra purge call to help debugging

--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import requests
 from structlog import wrap_logger
 
-from acceptance_tests.utilities.pubsub_helper import purge_aims_new_address_topic
+from acceptance_tests.utilities.pubsub_helper import purge_aims_new_address_subscription
 from acceptance_tests.utilities.rabbit_helper import purge_queues
 from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
@@ -63,10 +63,10 @@ def before_tag(context, tag):
         context.action_plan_id = Config.CENSUS_ACTION_PLAN_ID
         context.collection_exercise_id = Config.CENSUS_COLLECTION_EXERCISE_ID
     if tag == 'purge_aims_topic':
-        purge_aims_new_address_topic()
+        purge_aims_new_address_subscription()
 
         # Temporary extra purge call to help debugging
-        purge_aims_new_address_topic()
+        purge_aims_new_address_subscription()
 
 
 def after_tag(_, tag):

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -7,7 +7,7 @@ from behave import step
 from acceptance_tests.features.steps.receipt import _get_emitted_case
 from acceptance_tests.utilities.event_helper import check_case_created_message_is_emitted
 from acceptance_tests.utilities.pubsub_helper import synchronous_consume_of_aims_pubsub_topic, \
-    purge_aims_new_address_topic
+    purge_aims_new_address_subscription
 from acceptance_tests.utilities.rabbit_context import RabbitContext
 from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue
 from acceptance_tests.utilities.test_case_helper import test_helper
@@ -608,7 +608,7 @@ def new_address_sent_to_aims(context):
 
     # Temporary extra purge for debug logging
     if actual_case['id'] != context.case_id:
-        purge_aims_new_address_topic()
+        purge_aims_new_address_subscription()
 
     test_helper.assertEqual(actual_case['id'], context.case_id)
     test_helper.assertEqual(actual_address['uprn'], expected_dummy_uprn)

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -48,7 +48,7 @@ def purge_aims_new_address_subscription():
         subscriber.seek(subscription_path, time=timestamp)
     except MethodNotImplemented as e:
         # Seek is not implemented by the pubsub-emulator
-        print('PubSub seek not implemented by server, falling back on attempting to pull/ack all messages', e)
+        print(f'{e}, falling back on attempting to pull/ack all messages:')
         ack_all_on_aims_new_address_subscription()
 
 

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -1,7 +1,9 @@
 import json
 import logging
-from google.cloud import pubsub_v1
 
+from google.cloud import pubsub_v1
+from google.cloud.exceptions import MethodNotImplemented
+from google.protobuf.timestamp_pb2 import Timestamp
 from structlog import wrap_logger
 
 from config import Config
@@ -9,6 +11,8 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 subscriber = pubsub_v1.SubscriberClient()
+aims_subscription_path = subscriber.subscription_path(Config.AIMS_NEW_ADDRESS_PROJECT,
+                                                      Config.AIMS_NEW_ADDRESS_SUBSCRIPTION)
 
 
 def publish_to_pubsub(message, project, topic, **kwargs):
@@ -33,11 +37,24 @@ def synchronous_consume_of_aims_pubsub_topic(context):
     subscriber.acknowledge(subscription_path, ack_ids)
 
 
-def purge_aims_new_address_topic():
-    max_messages = 100
+def purge_aims_new_address_subscription():
     subscription_path = subscriber.subscription_path(Config.AIMS_NEW_ADDRESS_PROJECT,
                                                      Config.AIMS_NEW_ADDRESS_SUBSCRIPTION)
-    response = subscriber.pull(subscription_path, max_messages=max_messages, timeout=5)
+    timestamp = Timestamp()
+    timestamp.GetCurrentTime()
+    try:
+        # Try purging via the seek method
+        # Seeking to now should ack any messages published before this moment
+        subscriber.seek(subscription_path, time=timestamp)
+    except MethodNotImplemented as e:
+        # Seek is not implemented by the pubsub-emulator
+        print('PubSub seek not implemented by server, falling back on attempting to pull/ack all messages', e)
+        ack_all_on_aims_new_address_subscription()
+
+
+def ack_all_on_aims_new_address_subscription():
+    max_messages_per_attempt = 100
+    response = subscriber.pull(aims_subscription_path, max_messages=max_messages_per_attempt, timeout=5)
 
     # Temporary extra debug logging
     if response.received_messages:
@@ -48,8 +65,8 @@ def purge_aims_new_address_topic():
     ack_ids = [message.ack_id for message in response.received_messages]
 
     if ack_ids:
-        subscriber.acknowledge(subscription_path, ack_ids)
+        subscriber.acknowledge(aims_subscription_path, ack_ids)
 
     # It's possible (though unlikely) that they could be > max_messages on the topic so keep deleting till empty
-    if len(response.received_messages) == max_messages:
-        purge_aims_new_address_topic()
+    if len(response.received_messages) == max_messages_per_attempt:
+        ack_all_on_aims_new_address_subscription()

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -46,7 +46,7 @@ def purge_aims_new_address_subscription():
         subscriber.seek(aims_subscription_path, time=timestamp)
     except MethodNotImplemented as e:
         # Seek is not implemented by the pubsub-emulator
-        print(f'{e}, falling back on attempting to pull/ack all messages:')
+        print(f'{e}, falling back on attempting to pull/ack all messages')
         ack_all_on_aims_new_address_subscription()
 
 

--- a/acceptance_tests/utilities/pubsub_helper.py
+++ b/acceptance_tests/utilities/pubsub_helper.py
@@ -38,14 +38,12 @@ def synchronous_consume_of_aims_pubsub_topic(context):
 
 
 def purge_aims_new_address_subscription():
-    subscription_path = subscriber.subscription_path(Config.AIMS_NEW_ADDRESS_PROJECT,
-                                                     Config.AIMS_NEW_ADDRESS_SUBSCRIPTION)
     timestamp = Timestamp()
     timestamp.GetCurrentTime()
     try:
         # Try purging via the seek method
         # Seeking to now should ack any messages published before this moment
-        subscriber.seek(subscription_path, time=timestamp)
+        subscriber.seek(aims_subscription_path, time=timestamp)
     except MethodNotImplemented as e:
         # Seek is not implemented by the pubsub-emulator
         print(f'{e}, falling back on attempting to pull/ack all messages:')


### PR DESCRIPTION
# Motivation and Context
The 'pull as many messages off the subscription as we can' method seems to work fine for purging the AIM's subscription locally. However, in the cloud it was unreliable and the scenario was failing on left over messages. The `seek` method is a much nicer way of purging the subscription which I am hoping will work reliably in the cloud, but is not implemented by the local pubsub-emulator. 

# What has changed
* Try to purge with the seek method first
* Fall back on the 'ack everything' method if seek is not implemented

# How to test?
The scenario should still pass locally and will hopefully work better in GCP too.

# Links
https://trello.com/c/hKGx5se1/1291-failing-at-aims-pubsub-purge