### PR TITLE
View All Case Details

### DIFF
--- a/acceptance_tests/features/ops_ui.feature
+++ b/acceptance_tests/features/ops_ui.feature
@@ -1,0 +1,20 @@
+Feature: Finding cases on R-ops UI
+
+  Scenario: Finding cases via postcode
+    Given sample file "sample_2_english_units_postcode_search.csv" is loaded successfully
+    And a user is on the r-ops-ui home page ready to search
+    When a user searches for cases via postcode
+    Then the cases are returned to the user
+
+
+  Scenario: Seeing all case details
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    When a user has searched for cases
+    Then the user can see all case details for chosen case
+
+
+  Scenario: RM_UAC_CREATED event is not visible on case details page
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    And a UAC fulfilment request "UACHHT1" message for a created case is sent
+    When a user has searched for cases
+    Then the user can see all case details for chosen case except for the RM_UAC_CREATED event

--- a/acceptance_tests/features/postcode_search.feature
+++ b/acceptance_tests/features/postcode_search.feature
@@ -1,7 +1,0 @@
-Feature: Finding cases via postcode on R-ops UI
-
-  Scenario: Finding cases on r-ops ui via postcode
-    Given sample file "sample_2_english_units_postcode_search.csv" is loaded successfully
-    And a user is on the r-ops-ui home page ready to search
-    When a user searches for cases via postcode
-    Then the cases are returned to the user

--- a/acceptance_tests/features/steps/ops_ui.py
+++ b/acceptance_tests/features/steps/ops_ui.py
@@ -23,7 +23,7 @@ def get_cases_from_postcode(context, postcode):
 def rops_case_details_page(context):
     context.case_details = context.case_created_events[0]['payload']['collectionCase']
     case_details_page_response = requests.get(
-        f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}/case_details?case_id={context.first_case["id"]}')
+        f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}/case-details?case_id={context.first_case["id"]}')
     case_details_page_response.raise_for_status()
     case_details_text = case_details_page_response.text
 

--- a/acceptance_tests/features/steps/ops_ui.py
+++ b/acceptance_tests/features/steps/ops_ui.py
@@ -18,7 +18,26 @@ def get_cases_from_postcode(context, postcode):
     context.number_of_cases = len(response_json)
 
 
+@step("the user can see all case details for chosen case")
+@step("the user can see all case details for chosen case except for the RM_UAC_CREATED event")
+def rops_case_details_page(context):
+    context.case_details = context.case_created_events[0]['payload']['collectionCase']
+    case_details_page_response = requests.get(
+        f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}/case_details?case_id={context.first_case["id"]}')
+    case_details_page_response.raise_for_status()
+    case_details_text = case_details_page_response.text
+
+    assert context.case_details["caseRef"] in case_details_text
+    assert context.case_details["address"]["addressLevel"] in case_details_text
+    assert context.case_details["caseType"] in case_details_text
+    assert str(context.case_details["skeleton"]) in case_details_text
+    assert context.case_details["collectionExerciseId"] in case_details_text
+    assert context.case_details["lsoa"] in case_details_text
+    assert "RM_UAC_CREATED" not in case_details_text
+
+
 @step("a user searches for cases via postcode")
+@step("a user has searched for cases")
 def rops_search_postcode(context):
     context.postcode = context.case_created_events[0]['payload']['collectionCase']['address']['postcode']
     get_cases_from_postcode(context, context.postcode)
@@ -28,6 +47,6 @@ def rops_search_postcode(context):
 
 
 @step('the cases are returned to the user')
-def rop_results(context):
+def rops_results(context):
     postcode_result_text = context.postcode_result.text
     assert f'{context.number_of_cases} results for postcode: "{context.postcode}"' in postcode_result_text


### PR DESCRIPTION
# Motivation and Context
Offers user ability to view all case and event details of selected case

# What has changed
New scenario to check user can see details for chosen case
New scenario checking details are not present when event is RM_UAC_CREATED

# How to test?
Build case-api and ops-ui images and run feature

# Links
https://trello.com/c/ZxxGq4aT/1222-r-ops-ui-view-all-case-details-13
https://rops-prototypes.netlify.app/prototypes/rops-management/version-2/1-acacia-avenue/index.html