### PR TITLE
1223 R-ops UI Link a QID to a case

### DIFF
--- a/acceptance_tests/features/ops_ui.feature
+++ b/acceptance_tests/features/ops_ui.feature
@@ -16,3 +16,27 @@ Feature: Finding cases on R-ops UI
     And a UAC fulfilment request "UACHHT1" message for a created case is sent
     When a user navigates to the case details page for the chosen case
     Then the user can see all case details for the chosen case except for the RM_UAC_CREATED event
+
+  Scenario: Going to QID link detail page
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    And an unaddressed QID request message of questionnaire type 01 is sent
+    And a UAC updated message with "01" questionnaire type is emitted
+    And a user navigates to the case details page for the chosen case
+    When the user enters a qid they would like to link to the case
+    Then the qid details page appears
+
+  Scenario: Linking QID to case on R ops UI
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    And an unaddressed QID request message of questionnaire type 01 is sent
+    And a UAC updated message with "01" questionnaire type is emitted
+    And a user navigates to the case details page for the chosen case
+    When the user submits a qid to be linked to the case
+    Then a qid linked message appears on the screen
+    And the correct events are logged for the loaded case events "[SAMPLE_LOADED,UAC_UPDATED,QUESTIONNAIRE_LINKED]"
+
+
+  Scenario: Attempting to link fake qid to case
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    And a user navigates to the case details page for the chosen case
+    When the user submits a fake qid to be linked to the case
+    Then a failed to find qid message appears on r ops ui

--- a/acceptance_tests/features/ops_ui.feature
+++ b/acceptance_tests/features/ops_ui.feature
@@ -17,26 +17,20 @@ Feature: Finding cases on R-ops UI
     When a user navigates to the case details page for the chosen case
     Then the user can see all case details for the chosen case except for the RM_UAC_CREATED event
 
-  Scenario: Going to QID link detail page
+  Scenario: Linking a QID to a case
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     And an unaddressed QID request message of questionnaire type 01 is sent
     And a UAC updated message with "01" questionnaire type is emitted
     And a user navigates to the case details page for the chosen case
-    When the user enters a qid they would like to link to the case
-    Then the qid details page appears
-
-  Scenario: Linking QID to case on R ops UI
-    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
-    And an unaddressed QID request message of questionnaire type 01 is sent
-    And a UAC updated message with "01" questionnaire type is emitted
-    And a user navigates to the case details page for the chosen case
-    When the user submits a qid to be linked to the case
-    Then a qid linked message appears on the screen
+    When the user submits a QID to be linked to the case
+    And the QID link confirmation page appears
+    And the user confirms they wish to link the QID to be linked
+    Then a QID link submitted message is flashed
+    And a UAC_UPDATED message is emitted linking the submitted QID to the chosen case
     And the correct events are logged for the loaded case events "[SAMPLE_LOADED,UAC_UPDATED,QUESTIONNAIRE_LINKED]"
 
-
-  Scenario: Attempting to link fake qid to case
+  Scenario: Attempting to link a bad qid to case
     Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
     And a user navigates to the case details page for the chosen case
-    When the user submits a fake qid to be linked to the case
-    Then a failed to find qid message appears on r ops ui
+    When the user submits a bad QID to be linked to the case
+    Then a failed to find QID message is flashed

--- a/acceptance_tests/features/steps/ops_ui.py
+++ b/acceptance_tests/features/steps/ops_ui.py
@@ -1,10 +1,13 @@
+import functools
 import operator
 
 import requests
 from behave import step, then
-from toolbox.tests import unittest_helper
 
 from acceptance_tests.utilities.case_api_helper import get_cases_from_postcode
+from acceptance_tests.utilities.rabbit_helper import start_listening_to_rabbit_queue, \
+    store_all_uac_updated_msgs_by_collection_exercise_id
+from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
@@ -13,7 +16,7 @@ def rops_home_page(context):
     home_page_response = requests.get(f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}')
     home_page_response.raise_for_status()
     home_text = home_page_response.text
-    unittest_helper.assertIn('Enter a postcode', home_text)
+    test_helper.assertIn('Enter a postcode', home_text)
 
 
 @step('a user navigates to the case details page for the chosen case')
@@ -24,17 +27,19 @@ def rops_get_case_details_page(context):
     case_details_page_response.raise_for_status()
     context.case_details_text = case_details_page_response.text
 
+    test_helper.assertIn('Link QID', context.case_details_text)
+
 
 @step("the user can see all case details for the chosen case")
 @step("the user can see all case details for the chosen case except for the RM_UAC_CREATED event")
 def rops_check_case_details_page(context):
-    unittest_helper.assertIn(context.case_details["caseRef"], context.case_details_text)
-    unittest_helper.assertIn(context.case_details["address"]["addressLevel"], context.case_details_text)
-    unittest_helper.assertIn(context.case_details["caseType"], context.case_details_text)
-    unittest_helper.assertIn(str(context.case_details["skeleton"]), context.case_details_text)
-    unittest_helper.assertIn(context.case_details["collectionExerciseId"], context.case_details_text)
-    unittest_helper.assertIn(context.case_details["lsoa"], context.case_details_text)
-    unittest_helper.assertNotIn("RM_UAC_CREATED", context.case_details_text)
+    test_helper.assertIn(context.case_details["caseRef"], context.case_details_text)
+    test_helper.assertIn(context.case_details["address"]["addressLevel"], context.case_details_text)
+    test_helper.assertIn(context.case_details["caseType"], context.case_details_text)
+    test_helper.assertIn(str(context.case_details["skeleton"]), context.case_details_text)
+    test_helper.assertIn(context.case_details["collectionExerciseId"], context.case_details_text)
+    test_helper.assertIn(context.case_details["lsoa"], context.case_details_text)
+    test_helper.assertNotIn("RM_UAC_CREATED", context.case_details_text)
 
 
 @step("a user searches for cases by postcode")
@@ -54,81 +59,110 @@ def rops_results(context):
                           key=operator.itemgetter('organisationName', 'addressLine1', 'caseType', 'addressLevel'))
 
     # Check the order returned by case API
-    unittest_helper.assertEqual(context.cases_by_postcode, sorted_cases,
-                                'The API should return the cases in the correct order')
+    test_helper.assertEqual(context.cases_by_postcode, sorted_cases,
+                            'The API should return the cases in the correct order')
 
     # Check the expected data is on the page
     postcode_result_text = context.postcode_result.text
-    unittest_helper.assertIn(f'{context.number_of_cases} results for postcode: "{context.postcode}"',
-                             postcode_result_text)
+    test_helper.assertIn(f'{context.number_of_cases} results for postcode: "{context.postcode}"',
+                         postcode_result_text)
     case_page_locations = []
     for case in context.cases_by_postcode:
-        unittest_helper.assertIn(case['caseRef'], postcode_result_text)
-        unittest_helper.assertIn(case['addressLine1'], postcode_result_text)
-        unittest_helper.assertIn(case['uprn'], postcode_result_text)
-        unittest_helper.assertIn(case['estabType'], postcode_result_text)
+        test_helper.assertIn(case['caseRef'], postcode_result_text)
+        test_helper.assertIn(case['addressLine1'], postcode_result_text)
+        test_helper.assertIn(case['uprn'], postcode_result_text)
+        test_helper.assertIn(case['estabType'], postcode_result_text)
         case_page_locations.append({'id': case['id'], 'location': postcode_result_text.find(case['caseRef'])})
 
     # Check the cases appear in the expected order on the page
     case_order_on_page = [case['id'] for case in sorted(case_page_locations, key=operator.itemgetter('location'))]
-    unittest_helper.assertEqual(case_order_on_page, [case['id'] for case in sorted_cases],
-                                'The order of cases should be in order on the page')
+    test_helper.assertEqual(case_order_on_page, [case['id'] for case in sorted_cases],
+                            'The order of cases should be in order on the page')
 
 
-@step("the user submits a qid to be linked to the case")
+@step('the user confirms they wish to link the QID to be linked')
 def submit_qid_link_on_r_ops(context):
-    unittest_helper.assertIn('Submit QID Link', context.case_details_text)
-    payload = {'case_id': context.case_details['id'],
-               'qid': context.requested_qid}
-    context.qid_link_response = requests.post(
-        f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}/case-details/questionnaire-id'
-        f'/link/', data=payload)
-
-    unittest_helper.assertEqual(context.qid_link_response.status_code, 200)
+    test_helper.assertIn('Link QID', context.case_details_text)
+    context.qid_link_response = submit_rops_qid_link(case_id=context.case_details['id'], qid=context.requested_qid)
+    test_helper.assertEqual(context.qid_link_response.status_code, 200)
 
 
-@step("the user enters a qid they would like to link to the case")
-def entering_in_qid_to_see_if_it_exists(context):
-    payload = {'case_id': context.case_details['id'],
-               'qid': context.requested_qid}
-
-    context.qid_link_response = requests.get(
-        f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}/case-details'
-        f'/questionnaire-id/', params=payload)
-
-    unittest_helper.assertEqual(context.qid_link_response.status_code, 200)
+@step('the user submits a QID to be linked to the case')
+@step("the user enters a QID they would like to link to the case")
+def get_case_details_link_qid(context):
+    context.qid_link_response = get_rops_qid_link_page(case_id=context.case_details['id'], qid=context.requested_qid)
+    test_helper.assertEqual(context.qid_link_response.status_code, 200)
 
 
-@step("the user submits a fake qid to be linked to the case")
+@step('the QID link confirmation page appears')
+def check_qid_link_confirmation_page(context):
+    qid_link_page = context.qid_link_response.text
+    test_helper.assertIn('Confirm linking this QID and Case ID', qid_link_page)
+    test_helper.assertIn(f'<b>QID:</b> {context.requested_qid}', qid_link_page)
+    test_helper.assertIn(f'<b>Case ID:</b> {context.case_details["id"]}', qid_link_page)
+    test_helper.assertIn('Link QID', qid_link_page)
+
+
+@step("the user submits a bad qid to be linked to the case")
 def search_for_fake_qid(context):
-    unittest_helper.assertIn('Submit QID Link', context.case_details_text)
-    payload = {'case_id': context.case_details['id'],
-               'qid': '123456789'}
-    context.qid_link_response = requests.get(
-        f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}/case-details'
-        f'/questionnaire-id/', params=payload)
+    test_helper.assertIn('Link QID', context.case_details_text)
+    context.qid_link_response = get_rops_qid_link_page(case_id=context.case_details['id'], qid='nonsense')
 
-    unittest_helper.assertEqual(context.qid_link_response.status_code, 200)
+    test_helper.assertEqual(context.qid_link_response.status_code, 200)
 
 
-@then("a qid linked message appears on the screen")
+@then("a QID link submitted message is flashed")
 def qid_linked_message_appears(context):
     response_text = context.qid_link_response.text
 
-    unittest_helper.assertIn('QID link has been submitted', response_text)
-    unittest_helper.assertIn('QUESTIONNAIRE_LINKED', response_text)
-    unittest_helper.assertIn(f'{context.requested_qid}', response_text)
+    test_helper.assertIn('QID link has been submitted', response_text)
 
 
-@then("a failed to find qid message appears on r ops ui")
+@then("a failed to find QID message is flashed")
 def qid_failed_message(context):
     response_text = context.qid_link_response.text
 
-    unittest_helper.assertIn('QID does not exist in RM', response_text)
+    test_helper.assertIn('QID does not exist in RM', response_text)
 
 
-@then("the qid details page appears")
+@then("the QID details page is flashed")
 def qid_details_page(context):
     response_text = context.qid_link_response.text
 
-    unittest_helper.assertIn(f'<b>questionnaireId:</b> {context.requested_qid}', response_text)
+    test_helper.assertIn(f'<b>QID:</b> {context.requested_qid}', response_text)
+
+
+@step('a UAC_UPDATED message is emitted linking the submitted QID to the chosen case')
+def check_uac_updated_message(context):
+    check_correct_uac_updated_message_is_emitted_for_rops_link(context)
+
+
+def get_rops_qid_link_page(case_id, qid):
+    response = requests.get(
+        f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}/case-details/link-qid/',
+        params={'case_id': case_id, 'qid': qid})
+    response.raise_for_status()
+    return response
+
+
+def submit_rops_qid_link(case_id, qid):
+    response = requests.post(
+        f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}/case-details/link-qid/submit/',
+        data={'case_id': case_id, 'qid': qid})
+    response.raise_for_status()
+    return response
+
+
+def check_correct_uac_updated_message_is_emitted_for_rops_link(context):
+    context.messages_received = []
+    start_listening_to_rabbit_queue(Config.RABBITMQ_RH_OUTBOUND_UAC_QUEUE,
+                                    functools.partial(store_all_uac_updated_msgs_by_collection_exercise_id,
+                                                      context=context,
+                                                      expected_msg_count=1,
+                                                      collection_exercise_id=context.collection_exercise_id))
+
+    uac_updated_payload = context.messages_received[0]['payload']['uac']
+    test_helper.assertEqual(uac_updated_payload['caseId'], context.case_details['id'],
+                            'UAC updated event case ID does not match the case it was requested for')
+    test_helper.assertEqual(uac_updated_payload['questionnaireId'], context.requested_qid,
+                            'UAC updated event QID does not match what was submitted to R-ops')

--- a/acceptance_tests/features/steps/ops_ui.py
+++ b/acceptance_tests/features/steps/ops_ui.py
@@ -100,7 +100,7 @@ def entering_in_qid_to_see_if_it_exists(context):
 
 
 @step("the user submits a fake qid to be linked to the case")
-def submit_qid_link_on_r_ops(context):
+def search_for_fake_qid(context):
     unittest_helper.assertIn('Submit QID Link', context.case_details_text)
     payload = {'case_id': context.case_details['id'],
                'qid': '123456789'}
@@ -109,7 +109,6 @@ def submit_qid_link_on_r_ops(context):
         f'/questionnaire-id/', params=payload)
 
     unittest_helper.assertEqual(context.qid_link_response.status_code, 200)
-
 
 
 @then("a qid linked message appears on the screen")

--- a/acceptance_tests/features/steps/ops_ui.py
+++ b/acceptance_tests/features/steps/ops_ui.py
@@ -102,9 +102,11 @@ def entering_in_qid_to_see_if_it_exists(context):
 @step("the user submits a fake qid to be linked to the case")
 def submit_qid_link_on_r_ops(context):
     unittest_helper.assertIn('Submit QID Link', context.case_details_text)
+    payload = {'case_id': context.case_details['id'],
+               'qid': '123456789'}
     context.qid_link_response = requests.get(
         f'{Config.PROTOCOL}://{Config.ROPS_HOST}:{Config.ROPS_PORT}/case-details'
-        f'/questionnaire-id/?qid=123456789&case_id={context.case_details["id"]}')
+        f'/questionnaire-id/', params=payload)
 
     unittest_helper.assertEqual(context.qid_link_response.status_code, 200)
 


### PR DESCRIPTION
# Checklist
Reminder: If any changes have been released in the [census-rm-sample-loader](https://github.com/ONSdigital/census-rm-sample-loader) or [census-rm-toolbox](https://github.com/ONSdigital/census-rm-toolbox/) then the version pins in the Pipfile need to be updated.
* [x] Updated census-rm-toolbox version pin (if applicable)
* [x] Updated census-rm-sample-loader version pin (if applicable)

# Motivation and Context
We need tests for QID linking via R-Ops UI

# What has changed
* Add scenarios to test QID linking via R-Ops UI

# How to test?
Run against feature branch service builds.

# Links
https://trello.com/c/6QdthBHC/1223-r-ops-ui-link-a-qid-to-a-case-13