### PR TITLE
test for new address to field with uaa set

### DIFF
--- a/acceptance_tests/features/bulk_processing.feature
+++ b/acceptance_tests/features/bulk_processing.feature
@@ -12,6 +12,7 @@ Feature: Bulk event CSV files can be processed
     When the bulk new address file is processed
     Then CASE_CREATED events are emitted for all the new addressed supplied
     And the new address cases are ingested into the database
+    And the new address cases are sent to field as CREATE with UAA true
 
   Scenario: A bulk invalid address file is successfully ingested
     Given sample file "sample_input_wales_census_spec.csv" is loaded successfully

--- a/acceptance_tests/utilities/fieldwork_helper.py
+++ b/acceptance_tests/utilities/fieldwork_helper.py
@@ -6,7 +6,7 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-def fieldwork_create_message_callback(ch, method, _properties, body, context):
+def fieldwork_create_message_callback(ch, method, _properties, body, context, store_msg=None):
     action_instruction = json.loads(body)
 
     if not action_instruction['actionInstruction'] == 'CREATE':
@@ -19,6 +19,9 @@ def fieldwork_create_message_callback(ch, method, _properties, body, context):
             _message_valid(case, action_instruction)
             del context.expected_cases_for_action[index]
             ch.basic_ack(delivery_tag=method.delivery_tag)
+
+            if store_msg:
+                store_msg.append(action_instruction)
 
             break
     else:

--- a/acceptance_tests/utilities/fieldwork_helper.py
+++ b/acceptance_tests/utilities/fieldwork_helper.py
@@ -6,7 +6,7 @@ from acceptance_tests.utilities.test_case_helper import test_helper
 from config import Config
 
 
-def fieldwork_create_message_callback(ch, method, _properties, body, context, store_msg=None):
+def fieldwork_create_message_callback(ch, method, _properties, body, context):
     action_instruction = json.loads(body)
 
     if not action_instruction['actionInstruction'] == 'CREATE':
@@ -19,9 +19,6 @@ def fieldwork_create_message_callback(ch, method, _properties, body, context, st
             _message_valid(case, action_instruction)
             del context.expected_cases_for_action[index]
             ch.basic_ack(delivery_tag=method.delivery_tag)
-
-            if store_msg:
-                store_msg.append(action_instruction)
 
             break
     else:


### PR DESCRIPTION
# Checklist
Reminder: If any changes have been released in the [census-rm-sample-loader](https://github.com/ONSdigital/census-rm-sample-loader) or [census-rm-toolbox](https://github.com/ONSdigital/census-rm-toolbox/) then the version pins in the Pipfile need to be updated.
* [ ] Updated census-rm-toolbox version pin (if applicable)
* [ ] Updated census-rm-sample-loader version pin (if applicable)

# Motivation and Context
Clerical new addresses to be sent to field

# What has changed
Test checks that CREATE action instructions are sent to field with uaa set when received from bulk new address mcThingy

# How to test?
With other apps from the ticket

https://trello.com/b/yarvSxGu/census-2021-response-management