### PR TITLE
New Scenario For newAddressReported

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -58,11 +58,20 @@ Feature: Address updates
 
   Scenario: New address event received for CE case with sourceCaseId and Secure Establishment True
     Given sample file "sample_1_english_CE_secure_estab.csv" is loaded successfully
-    When a NEW_ADDRESS_REPORTED event for a CE case is sent from "FIELD" with sourceCaseId
+    When a NEW_ADDRESS_REPORTED event for a CE case is sent from "FIELD" with sourceCaseId and secureType true
     Then a case created event is emitted
     And the CE case can be retrieved and contains the correct properties when the event had details
     And the events logged for the case are [NEW_ADDRESS_REPORTED]
     And the new address reported cases are sent to field as CREATE with secureEstablishment as true
+
+
+  Scenario: New address event received for CE case with sourceCaseId and Secure Establishment False
+    Given sample file "sample_1_english_CE_secure_estab.csv" is loaded successfully
+    When a NEW_ADDRESS_REPORTED event for a CE case is sent from "FIELD" with sourceCaseId and secureType false
+    Then a case created event is emitted
+    And the CE case can be retrieved and contains the correct properties when the event had details
+    And the events logged for the case are [NEW_ADDRESS_REPORTED]
+    And the new address reported cases are sent to field as CREATE with secureEstablishment as false
 
 
   Scenario: New address event received with sourceCaseId

--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -58,7 +58,7 @@ Feature: Address updates
 
   Scenario: New address event received for CE case with sourceCaseId and Secure Establishment True
     Given sample file "sample_1_english_CE_secure_estab.csv" is loaded successfully
-    When a NEW_ADDRESS_REPORTED event for a CE case is sent from "FIELD" with sourceCaseId and secureType true
+    When a NEW_ADDRESS_REPORTED event for a CE case is sent from "FIELD" with sourceCaseId and secureType "True"
     Then a case created event is emitted
     And the CE case can be retrieved and contains the correct properties when the event had details
     And the events logged for the case are [NEW_ADDRESS_REPORTED]
@@ -67,7 +67,7 @@ Feature: Address updates
 
   Scenario: New address event received for CE case with sourceCaseId and Secure Establishment False
     Given sample file "sample_1_english_CE_secure_estab.csv" is loaded successfully
-    When a NEW_ADDRESS_REPORTED event for a CE case is sent from "FIELD" with sourceCaseId and secureType false
+    When a NEW_ADDRESS_REPORTED event for a CE case is sent from "FIELD" with sourceCaseId and secureType "False"
     Then a case created event is emitted
     And the CE case can be retrieved and contains the correct properties when the event had details
     And the events logged for the case are [NEW_ADDRESS_REPORTED]

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -296,7 +296,8 @@ def new_address_reported_event_with_source_case_id(context, sender):
 
 
 @step(
-    'a NEW_ADDRESS_REPORTED event for a CE case is sent from "{sender}" with sourceCaseId and secureType "{secure_type}"')
+    'a NEW_ADDRESS_REPORTED event for a CE case is sent from "{sender}" with sourceCaseId '
+    'and secureType "{secure_type}"')
 def ce_new_address_reported_event_with_source_case_id_and_secureType_true(context, sender, secure_type):
     context.case_id = str(uuid.uuid4())
     context.collection_exercise_id = str(uuid.uuid4())

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -295,8 +295,8 @@ def new_address_reported_event_with_source_case_id(context, sender):
             routing_key=Config.RABBITMQ_ADDRESS_ROUTING_KEY)
 
 
-@step('a NEW_ADDRESS_REPORTED event for a CE case is sent from "{sender}" with sourceCaseId')
-def ce_new_address_reported_event_with_source_case_id(context, sender):
+@step('a NEW_ADDRESS_REPORTED event for a CE case is sent from "{sender}" with sourceCaseId and secureType true')
+def ce_new_address_reported_event_with_source_case_id_and_secureType_true(context, sender):
     context.case_id = str(uuid.uuid4())
     context.collection_exercise_id = str(uuid.uuid4())
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
@@ -334,6 +334,59 @@ def ce_new_address_reported_event_with_source_case_id(context, sender):
                             "longitude": "-1.238193",
                             "estabType": "HOSPITAL",
                             "secureType": True,
+                            "uprn": "1214242"
+                        }
+                    }
+                }
+            }
+        }
+    )
+    with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
+        rabbit.publish_message(
+            message=message,
+            content_type='application/json',
+            routing_key=Config.RABBITMQ_ADDRESS_ROUTING_KEY)
+
+
+@step('a NEW_ADDRESS_REPORTED event for a CE case is sent from "{sender}" with sourceCaseId and secureType false')
+def ce_new_address_reported_event_with_source_case_id_and_secureType_false(context, sender):
+    context.case_id = str(uuid.uuid4())
+    context.collection_exercise_id = str(uuid.uuid4())
+    context.first_case = context.case_created_events[0]['payload']['collectionCase']
+    context.sourceCaseId = str(context.first_case['id'])
+    message = json.dumps(
+        {
+            "event": {
+                "type": "NEW_ADDRESS_REPORTED",
+                "source": "FIELDWORK_GATEWAY",
+                "channel": sender,
+                "dateTime": "2011-08-12T20:17:46.384Z",
+                "transactionId": "d9126d67-2830-4aac-8e52-47fb8f84d3b9"
+            },
+            "payload": {
+                "newAddress": {
+                    "sourceCaseId": context.sourceCaseId,
+                    "collectionCase": {
+                        "id": context.case_id,
+                        "caseType": "CE",
+                        "survey": "CENSUS",
+                        "fieldCoordinatorId": "SO_23",
+                        "fieldOfficerId": "SO_23_123",
+                        "collectionExerciseId": context.collection_exercise_id,
+                        "ceExpectedCapacity": 5,
+                        "address": {
+                            "addressLine1": "123",
+                            "addressLine2": "Fake caravan park",
+                            "addressLine3": "The long road",
+                            "townName": "Trumpton",
+                            "postcode": "SO190PG",
+                            "region": "E00001234",
+                            "addressType": "CE",
+                            "addressLevel": "E",
+                            "latitude": "50.917428",
+                            "longitude": "-1.238193",
+                            "estabType": "HOSPITAL",
+                            "secureType": False,
                             "uprn": "1214242"
                         }
                     }
@@ -852,7 +905,7 @@ def new_address_sent_to_aims(context):
 
 
 @step("the new address reported cases are sent to field as CREATE with secureEstablishment as true")
-def new_addresses_sent_to_field(context):
+def new_addresses_sent_to_field_secureType_true(context):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE,
                                     functools.partial(
@@ -862,6 +915,19 @@ def new_addresses_sent_to_field(context):
     field_msg = context.messages_received[0]
     test_helper.assertEqual(field_msg['actionInstruction'], 'CREATE')
     test_helper.assertTrue(field_msg['secureEstablishment'])
+
+
+@step("the new address reported cases are sent to field as CREATE with secureEstablishment as false")
+def new_addresses_sent_to_field_secureType_false(context):
+    context.messages_received = []
+    start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE,
+                                    functools.partial(
+                                        store_all_msgs_in_context, context=context,
+                                        expected_msg_count=1))
+
+    field_msg = context.messages_received[0]
+    test_helper.assertEqual(field_msg['actionInstruction'], 'CREATE')
+    test_helper.assertFalse(field_msg['secureEstablishment'])
 
 
 def _check_case_address_details(case, expected_uprn, expected_estab_uprn=None, extra_address_details=None):

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -295,8 +295,9 @@ def new_address_reported_event_with_source_case_id(context, sender):
             routing_key=Config.RABBITMQ_ADDRESS_ROUTING_KEY)
 
 
-@step('a NEW_ADDRESS_REPORTED event for a CE case is sent from "{sender}" with sourceCaseId and secureType true')
-def ce_new_address_reported_event_with_source_case_id_and_secureType_true(context, sender):
+@step(
+    'a NEW_ADDRESS_REPORTED event for a CE case is sent from "{sender}" with sourceCaseId and secureType "{secure_type}"')
+def ce_new_address_reported_event_with_source_case_id_and_secureType_true(context, sender, secure_type):
     context.case_id = str(uuid.uuid4())
     context.collection_exercise_id = str(uuid.uuid4())
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
@@ -333,60 +334,7 @@ def ce_new_address_reported_event_with_source_case_id_and_secureType_true(contex
                             "latitude": "50.917428",
                             "longitude": "-1.238193",
                             "estabType": "HOSPITAL",
-                            "secureType": True,
-                            "uprn": "1214242"
-                        }
-                    }
-                }
-            }
-        }
-    )
-    with RabbitContext(exchange=Config.RABBITMQ_EVENT_EXCHANGE) as rabbit:
-        rabbit.publish_message(
-            message=message,
-            content_type='application/json',
-            routing_key=Config.RABBITMQ_ADDRESS_ROUTING_KEY)
-
-
-@step('a NEW_ADDRESS_REPORTED event for a CE case is sent from "{sender}" with sourceCaseId and secureType false')
-def ce_new_address_reported_event_with_source_case_id_and_secureType_false(context, sender):
-    context.case_id = str(uuid.uuid4())
-    context.collection_exercise_id = str(uuid.uuid4())
-    context.first_case = context.case_created_events[0]['payload']['collectionCase']
-    context.sourceCaseId = str(context.first_case['id'])
-    message = json.dumps(
-        {
-            "event": {
-                "type": "NEW_ADDRESS_REPORTED",
-                "source": "FIELDWORK_GATEWAY",
-                "channel": sender,
-                "dateTime": "2011-08-12T20:17:46.384Z",
-                "transactionId": "d9126d67-2830-4aac-8e52-47fb8f84d3b9"
-            },
-            "payload": {
-                "newAddress": {
-                    "sourceCaseId": context.sourceCaseId,
-                    "collectionCase": {
-                        "id": context.case_id,
-                        "caseType": "CE",
-                        "survey": "CENSUS",
-                        "fieldCoordinatorId": "SO_23",
-                        "fieldOfficerId": "SO_23_123",
-                        "collectionExerciseId": context.collection_exercise_id,
-                        "ceExpectedCapacity": 5,
-                        "address": {
-                            "addressLine1": "123",
-                            "addressLine2": "Fake caravan park",
-                            "addressLine3": "The long road",
-                            "townName": "Trumpton",
-                            "postcode": "SO190PG",
-                            "region": "E00001234",
-                            "addressType": "CE",
-                            "addressLevel": "E",
-                            "latitude": "50.917428",
-                            "longitude": "-1.238193",
-                            "estabType": "HOSPITAL",
-                            "secureType": False,
+                            "secureType": secure_type,
                             "uprn": "1214242"
                         }
                     }


### PR DESCRIPTION
# Motivation and Context
We want to record a property as secure so that future visits can be arranged if required

# What has changed
One new scenario to prove event overwrites secureType true value from loaded sample and produces a new case with it set to false

# How to test?
Run ATs and check DB

# Links
https://trello.com/c/4fnNI9lZ/1231-consume-secure-flag-on-newaddressreported-5
https://collaborate2.ons.gov.uk/confluence/pages/viewpage.action?pageId=40216113