### PR TITLE
Increase timeout waiting for Rabbit message, because pubsub connection glitch

### DIFF
--- a/acceptance_tests/utilities/rabbit_helper.py
+++ b/acceptance_tests/utilities/rabbit_helper.py
@@ -12,7 +12,7 @@ from config import Config
 logger = wrap_logger(logging.getLogger(__name__))
 
 
-def start_listening_to_rabbit_queue(queue, on_message_callback, timeout=30):
+def start_listening_to_rabbit_queue(queue, on_message_callback, timeout=60):
     rabbit = RabbitContext(queue_name=queue)
     connection = rabbit.open_connection()
 


### PR DESCRIPTION
# Motivation and Context
We wanna stop the 'noise' of AT false positives, during this high pressure time.

# What has changed
Increased timeout from 30 seconds to 60 seconds.

# How to test?
Let the nightly ATs run for a week or so.

# Links
Trello: https://trello.com/c/tkDf3eql