### PR TITLE
Send UPDATE to FWMT-G for FieldCaseUpdated (CE Units only)

### DIFF
--- a/acceptance_tests/features/field_case_updated.feature
+++ b/acceptance_tests/features/field_case_updated.feature
@@ -1,15 +1,23 @@
 Feature: Field Case Updated Events
 
   Scenario: A request to change the CE expected capacity for a case and a cancel message is sent to field
-    Given sample file "sample_1_english_CE_estab.csv" is loaded successfully
+    Given sample file "sample_1_english_CE_unit.csv" is loaded successfully
     When a Field Case Updated message has been sent with expected capacity as "0"
     Then a case_updated msg is emitted where "ceExpectedCapacity" is "0"
     And the events logged for the case are [SAMPLE_LOADED,FIELD_CASE_UPDATED]
     And a CANCEL action instruction is sent to field work management with address type "CE"
 
   Scenario: A request to change the CE expected capacity for a case and a cancel message is not sent to field
-    Given sample file "sample_1_english_CE_estab.csv" is loaded successfully
+    Given sample file "sample_1_english_CE_unit.csv" is loaded successfully
     When a Field Case Updated message has been sent with expected capacity as "3"
     Then a case_updated msg is emitted where "ceExpectedCapacity" is "3"
+    And the events logged for the case are [SAMPLE_LOADED,FIELD_CASE_UPDATED]
+    And an UPDATE action instruction is sent to field work management with address type "CE"
+
+  @regression
+  Scenario: A request to change the CE expected capacity for a CE estab case isn't sent to field
+    Given sample file "sample_1_english_CE_estab.csv" is loaded successfully
+    When a Field Case Updated message has been sent with expected capacity as "0"
+    Then a case_updated msg is emitted where "ceExpectedCapacity" is "0"
     And the events logged for the case are [SAMPLE_LOADED,FIELD_CASE_UPDATED]
     And no ActionInstruction is sent to FWMT

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -5,7 +5,8 @@ from behave import step
 
 from acceptance_tests.utilities.case_api_helper import get_ccs_qid_for_case_id
 from acceptance_tests.utilities.event_helper import check_if_event_list_is_exact_match
-from acceptance_tests.utilities.fieldwork_helper import field_work_cancel_callback
+from acceptance_tests.utilities.fieldwork_helper import field_work_cancel_callback, \
+    field_work_update_callback_without_faff
 from acceptance_tests.utilities.fulfilment_helper import send_print_fulfilment_request
 from acceptance_tests.utilities.pubsub_helper import publish_to_pubsub
 from acceptance_tests.utilities.rabbit_context import RabbitContext
@@ -96,6 +97,17 @@ def action_cancel_sent_to_fwm(context, address_type):
     context.messages_received = []
     start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE, functools.partial(
         field_work_cancel_callback, context=context))
+
+    test_helper.assertEqual(context.fwmt_emitted_case_id, context.first_case["id"])
+    test_helper.assertEqual(context.addressType, address_type)
+    test_helper.assertEqual(context.field_action_cancel_message['surveyName'], context.first_case['survey'])
+
+
+@step('an UPDATE action instruction is sent to field work management with address type "{address_type}"')
+def action_update_sent_to_fwm(context, address_type):
+    context.messages_received = []
+    start_listening_to_rabbit_queue(Config.RABBITMQ_OUTBOUND_FIELD_QUEUE, functools.partial(
+        field_work_update_callback_without_faff, context=context))
 
     test_helper.assertEqual(context.fwmt_emitted_case_id, context.first_case["id"])
     test_helper.assertEqual(context.addressType, address_type)

--- a/acceptance_tests/utilities/fieldwork_helper.py
+++ b/acceptance_tests/utilities/fieldwork_helper.py
@@ -65,6 +65,21 @@ def field_work_cancel_callback(ch, method, _properties, body, context):
     ch.stop_consuming()
 
 
+def field_work_update_callback_without_faff(ch, method, _properties, body, context):
+    action_cancel = json.loads(body)
+
+    if not action_cancel['actionInstruction'] == 'UPDATE':
+        ch.basic_nack(delivery_tag=method.delivery_tag)
+        test_helper.fail(f'Unexpected message on {Config.RABBITMQ_OUTBOUND_FIELD_QUEUE} case queue. '
+                         f'Got "{action_cancel["actionInstruction"]}", wanted "UPDATE"')
+
+    context.addressType = action_cancel['addressType']
+    context.fwmt_emitted_case_id = action_cancel['caseId']
+    context.field_action_cancel_message = action_cancel
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+    ch.stop_consuming()
+
+
 def field_work_update_callback(ch, method, _properties, body, context):
     action_instruction = json.loads(body)
 


### PR DESCRIPTION
# Motivation and Context
Business requirements have changed.

# What has changed
Only send to field CE units. Send update if the actual response count is greater than the expected response count.

# How to test?
Try updating the case using FIELD_CASE_UPDATED event on CE unit cases. When the actual response count is equal to or greater than the expected response count, the Field case should be cancelled, otherwise it should be updated. Other case types and address levels should either be ignored or throw errors, per prior behaviour.

# Links
Trello: https://trello.com/c/E1Qk7n8H