### PR TITLE
Updated new address reported test to check for create message

### DIFF
--- a/acceptance_tests/features/address.feature
+++ b/acceptance_tests/features/address.feature
@@ -75,11 +75,12 @@ Feature: Address updates
 
 
   Scenario: New address event received with sourceCaseId
-    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
-    When a NEW_ADDRESS_REPORTED event is sent from "FIELD" with sourceCaseId
+    Given sample file "sample_1_english_HH_unit_with_fieldcoordinator.csv" is loaded successfully
+    When a NEW_ADDRESS_REPORTED event is sent from "FIELD" with sourceCaseId and caseType "HH"
     Then a case created event is emitted
     And the case can be retrieved and contains the correct properties when the event had details
     And the events logged for the case are [NEW_ADDRESS_REPORTED]
+    And the new address reported cases are sent to field as CREATE with secureEstablishment as true
 
 
   Scenario: New address event received with sourceCaseId and minimal event fields

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -247,7 +247,8 @@ def new_address_reported_event_without_source_case_id_with_address_type(context,
 
 
 @step('a NEW_ADDRESS_REPORTED event is sent from "{sender}" with sourceCaseId')
-def new_address_reported_event_with_source_case_id(context, sender):
+@step('a NEW_ADDRESS_REPORTED event is sent from "{sender}" with sourceCaseId and casetype "{case_type}"')
+def new_address_reported_event_with_source_case_id(context, sender, case_type='SPG'):
     context.case_id = str(uuid.uuid4())
     context.collection_exercise_id = str(uuid.uuid4())
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
@@ -266,7 +267,7 @@ def new_address_reported_event_with_source_case_id(context, sender):
                     "sourceCaseId": context.sourceCaseId,
                     "collectionCase": {
                         "id": context.case_id,
-                        "caseType": "SPG",
+                        "caseType": case_type,
                         "survey": "CENSUS",
                         "fieldCoordinatorId": "SO_23",
                         "fieldOfficerId": "SO_23_123",
@@ -278,7 +279,7 @@ def new_address_reported_event_with_source_case_id(context, sender):
                             "townName": "Trumpton",
                             "postcode": "SO190PG",
                             "region": "E00001234",
-                            "addressType": "SPG",
+                            "addressType": case_type,
                             "addressLevel": "U",
                             "latitude": "50.917428",
                             "longitude": "-1.238193"

--- a/acceptance_tests/features/steps/address.py
+++ b/acceptance_tests/features/steps/address.py
@@ -253,6 +253,7 @@ def new_address_reported_event_with_source_case_id(context, sender, case_type='S
     context.collection_exercise_id = str(uuid.uuid4())
     context.first_case = context.case_created_events[0]['payload']['collectionCase']
     context.sourceCaseId = str(context.first_case['id'])
+    context.case_type = case_type
     message = json.dumps(
         {
             "event": {
@@ -267,7 +268,7 @@ def new_address_reported_event_with_source_case_id(context, sender, case_type='S
                     "sourceCaseId": context.sourceCaseId,
                     "collectionCase": {
                         "id": context.case_id,
-                        "caseType": case_type,
+                        "caseType": context.case_type,
                         "survey": "CENSUS",
                         "fieldCoordinatorId": "SO_23",
                         "fieldOfficerId": "SO_23_123",
@@ -279,7 +280,7 @@ def new_address_reported_event_with_source_case_id(context, sender, case_type='S
                             "townName": "Trumpton",
                             "postcode": "SO190PG",
                             "region": "E00001234",
-                            "addressType": case_type,
+                            "addressType": context.case_type,
                             "addressLevel": "U",
                             "latitude": "50.917428",
                             "longitude": "-1.238193"
@@ -506,7 +507,8 @@ def retrieve_case_from_source_case_id_and_event_details(context):
     test_helper.assertEqual(context.first_case['collectionExerciseId'], context.collection_exercise_id)
 
     source_case = context.case_created_events[0]['payload']['collectionCase']
-    _check_case_address_details(context.first_case, source_case['address']['uprn'], source_case['address']['estabUprn'])
+    _check_case_address_details(context.first_case, source_case['address']['uprn'],
+                                source_case['address']['estabUprn'], expected_address_type=context.case_type)
 
 
 @step('the CE case can be retrieved and contains the correct properties when the event had details')
@@ -880,14 +882,15 @@ def new_addresses_sent_to_field_secureType_false(context):
     test_helper.assertFalse(field_msg['secureEstablishment'])
 
 
-def _check_case_address_details(case, expected_uprn, expected_estab_uprn=None, extra_address_details=None):
+def _check_case_address_details(case, expected_uprn, expected_estab_uprn=None,
+                                extra_address_details=None, expected_address_type='SPG'):
     test_helper.assertEqual(case['addressLine1'], "123")
     test_helper.assertEqual(case['addressLine2'], "Fake caravan park")
     test_helper.assertEqual(case['addressLine3'], "The long road")
     test_helper.assertEqual(case['townName'], "Trumpton")
     test_helper.assertEqual(case['postcode'], "SO190PG")
     test_helper.assertEqual(case['region'], "E00001234")
-    test_helper.assertEqual(case['addressType'], "SPG")
+    test_helper.assertEqual(case['addressType'], expected_address_type)
     test_helper.assertEqual(case['addressLevel'], "U")
     test_helper.assertEqual(case['latitude'], "50.917428")
     test_helper.assertEqual(case['longitude'], "-1.238193")


### PR DESCRIPTION
# Checklist
Reminder: If any changes have been released in the [census-rm-sample-loader](https://github.com/ONSdigital/census-rm-sample-loader) or [census-rm-toolbox](https://github.com/ONSdigital/census-rm-toolbox/) then the version pins in the Pipfile need to be updated.
* [ ] Updated census-rm-toolbox version pin (if applicable)
* [ ] Updated census-rm-sample-loader version pin (if applicable)

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Field need to be sent back household addresses that come in from new address reported

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added steps to new address test to check that create message gets sent back to field after a create.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run tests with case processor branch

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/TEbkKVfG/)
