### PR TITLE
Attempt to fix intermittently failing AT

### DIFF
--- a/acceptance_tests/features/steps/ccs_property_listed.py
+++ b/acceptance_tests/features/steps/ccs_property_listed.py
@@ -24,7 +24,7 @@ def send_ccs_property_listed_event(context, interview_required):
 
 
 @step('the CCS Property Listed case is created with address type "{address_type}"')
-@retry(stop_max_attempt_number=10, wait_fixed=1000)
+@retry(stop_max_attempt_number=30, wait_fixed=1000)
 def check_case_created(context, address_type):
     response = requests.get(f'{Config.CASE_API_CASE_URL}{context.case_id}', params={'caseEvents': True})
     test_helper.assertEqual(response.status_code, 200, 'CCS Property Listed case not found')


### PR DESCRIPTION
# Motivation and Context
AT `Invalid address event for CCS unit level case` keeps failing. From looking at the application logs, there are no errors around this time. Increasing the retry timeout might help though.

# What has changed
Increased the retry timeout from 10 seconds to 30 seconds.

# How to test?
It's hard. I guess run the ATs a bunch of times and see if the problem goes away. It's hard to reproduce the problem reliably though.

# Links
Trello: nope