### PR TITLE
Add extra info to exceptions found after scenario end

### DIFF
--- a/acceptance_tests/features/environment.py
+++ b/acceptance_tests/features/environment.py
@@ -53,7 +53,14 @@ def after_scenario(_, scenario):
                 _clear_queues_for_bad_messages_and_reset_exception_manager()
                 logger.error('Unexpected exception(s) which were not due to eventual consistency timing',
                              exception_manager_response=response.json())
-                test_helper.fail('Unexpected exception(s) thrown by RM')
+
+                bad_message_details = []
+                list_of_bad_message_hashes = response.json()
+                for bad_message_hash in list_of_bad_message_hashes:
+                    response = requests.get(f'{Config.EXCEPTION_MANAGER_URL}/badmessage/{bad_message_hash}')
+                    bad_message_details.append(response.json())
+
+                test_helper.fail(f'Unexpected exception(s) thrown by RM. Details: {bad_message_details}')
 
 
 def before_tag(context, tag):


### PR DESCRIPTION
# Motivation and Context
There were problems with nightly ATs but not enough info to investigate further.

# What has changed
Added code to gather info on exceptions which haven't gone away at end of AT scenario.

# How to test?
Wait until the ATs fail overnight! It's hard... the problem is intermittent.

# Links
Nope