### PR TITLE
Receipting Bug Fix When AR > ER

### DIFF
--- a/acceptance_tests/features/receipt.feature
+++ b/acceptance_tests/features/receipt.feature
@@ -10,33 +10,53 @@ Feature: Case processor handles receipt message from pubsub service
     And if the field instruction "<instruction>" is not NONE a msg to field is emitted
 
     Examples:
-      | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
-      | HH        | U             | HH       | False     | True    | CANCEL      | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | HI        | U             | Ind      | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | FULFILMENT_REQUESTED,SAMPLE_LOADED                                                      | RESPONSE_RECEIVED,RM_UAC_CREATED |
-      | CE        | E             | CE1      | False     | True    | UPDATE      | sample_1_english_CE_estab.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | CE        | U             | Ind      | True      | AR >= E | CANCEL      | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | SPG       | E             | HH       | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | SPG       | U             | HH       | False     | True    | CANCEL      | sample_1_english_SPG_unit.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | SPG       | U             | Ind      | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
+      | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                  | individual case events           |
+      | HH        | U             | HH       | False     | True    | CANCEL      | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                     |                                  |
+      | HI        | U             | Ind      | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | FULFILMENT_REQUESTED,SAMPLE_LOADED                                  | RESPONSE_RECEIVED,RM_UAC_CREATED |
+      | CE        | E             | CE1      | False     | True    | UPDATE      | sample_1_english_CE_estab.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                     |                                  |
+      | CE        | U             | Ind      | True      | AR = E  | CANCEL      | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
+      | SPG       | E             | HH       | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | SAMPLE_LOADED,RESPONSE_RECEIVED                                     |                                  |
+      | SPG       | U             | HH       | False     | True    | CANCEL      | sample_1_english_SPG_unit.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                     |                                  |
+      | SPG       | U             | Ind      | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
 
     @regression
     Examples:
-      | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events           |
-      | HH        | U             | CE1      | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                                  |
-      | HH        | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
-      | HI        | U             | HH       | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,FULFILMENT_REQUESTED                                                      |                                  |
-      | HI        | U             | CE1      | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,FULFILMENT_REQUESTED                                                      |                                  |
-      | HI        | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
-      | CE        | E             | HH       | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                                  |
-      | CE        | E             | Ind      | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                                  |
-      | CE        | E             | Cont     | False     | False   | NONE        | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
-      | CE        | U             | HH       | True      | AR >= E | CANCEL      | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                                  |
-      | CE        | U             | CE1      | False     | False   | NONE        | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                                  |
-      | CE        | U             | Cont     | False     | False   | NONE        | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
-      | SPG       | E             | CE1      | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                                  |
-      | SPG       | U             | HH       | False     | True    | CANCEL      | sample_1_english_SPG_unit.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                                  |
-      | SPG       | U             | CE1      | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                                  |
-      | SPG       | U             | Cont     | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                                  |
+      | case type | address level | qid type | increment | receipt | instruction | sample file                   | country | loaded case events                                                                      | individual case events |
+      | HH        | U             | CE1      | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                        |
+      | HH        | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                        |
+      | HI        | U             | HH       | False     | True    | NONE        | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,FULFILMENT_REQUESTED                                                      |                        |
+      | HI        | U             | CE1      | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | SAMPLE_LOADED,FULFILMENT_REQUESTED                                                      |                        |
+      | HI        | U             | Cont     | False     | False   | NONE        | sample_1_english_HH_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                        |
+      | CE        | E             | HH       | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                        |
+      | CE        | E             | Ind      | True      | False   | UPDATE      | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED                     |                        |
+      | CE        | E             | Cont     | False     | False   | NONE        | sample_1_english_CE_estab.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                        |
+      | CE        | U             | HH       | True      | AR = E  | CANCEL      | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                        |
+      | CE        | U             | CE1      | False     | False   | NONE        | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                        |
+      | CE        | U             | Cont     | False     | False   | NONE        | sample_1_english_CE_unit.csv  | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                        |
+      | SPG       | E             | CE1      | False     | False   | NONE        | sample_1_ni_SPG_estab.csv     | N       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                        |
+      | SPG       | U             | HH       | False     | True    | CANCEL      | sample_1_english_SPG_unit.csv | E       | SAMPLE_LOADED,RESPONSE_RECEIVED                                                         |                        |
+      | SPG       | U             | CE1      | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,SAMPLE_LOADED,QUESTIONNAIRE_LINKED,UAC_UPDATED                        |                        |
+      | SPG       | U             | Cont     | False     | False   | NONE        | sample_1_english_SPG_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,PRINT_CASE_SELECTED,FULFILMENT_REQUESTED,SAMPLE_LOADED |                        |
+
+
+  Scenario Outline: CE U Receipted Cases output nothing to Field when AR > ER
+    Given sample file "<sample file>" is loaded successfully
+    And if required, a new qid and case are created for case type "<case type>" address level "<address level>" qid type "<qid type>" and country "<country>"
+    When the receipt msg is put on the GCP pubsub
+    And a uac_updated msg is emitted with active set to false for the receipted qid
+    And a case_updated msg is emitted where "receiptReceived" is "True"
+    And a CANCEL action instruction is sent to field work management with address type "CE"
+    And a new qid and case are created for case type "CE" address level "U" qid type "<qid type>" and country "E"
+    And the receipt msg is put on the GCP pubsub
+    And a uac_updated msg is emitted with active set to false for the receipted qid
+    Then the correct events are logged for loaded case events "[<loaded case events>]" and individual case events "[<individual case events>]"
+    And if the actual response count is incremented "<increment>" or the case is marked receipted "<receipt>" then there should be a case updated message of case type "<case type>"
+    And if the field instruction "<instruction>" is not NONE a msg to field is emitted
+
+    Examples:
+      | case type | address level | qid type | increment | receipt | instruction | sample file                  | country | loaded case events                                                                                                        | individual case events |
+      | CE        | U             | Ind      | True      | AR > E  | NONE        | sample_1_english_CE_unit.csv | E       | RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED,SAMPLE_LOADED,RESPONSE_RECEIVED,RM_UAC_CREATED,FULFILMENT_REQUESTED |                        |
+      | CE        | U             | HH       | True      | AR > E  | NONE        | sample_1_english_CE_unit.csv | E       | RESPONSE_RECEIVED,QUESTIONNAIRE_LINKED,UAC_UPDATED,SAMPLE_LOADED,RESPONSE_RECEIVED,QUESTIONNAIRE_LINKED,UAC_UPDATED       |                        |
 
 
   Scenario: Receipted Cases are excluded from print files

--- a/acceptance_tests/features/steps/receipt.py
+++ b/acceptance_tests/features/steps/receipt.py
@@ -296,10 +296,16 @@ def check_ce_actual_responses_and_receipted(context, incremented, receipted, cas
         if incremented == 'True':
             expected_actual_responses = expected_actual_responses + 1
 
+        if receipted == 'AR > E':
+            expected_actual_responses = expected_actual_responses + 1
+
         test_helper.assertEqual(emitted_case['ceActualResponses'], expected_actual_responses)
 
-    if receipted == 'AR >= E':
-        receipted = emitted_case['ceActualResponses'] >= emitted_case['ceExpectedCapacity']
+    if receipted == 'AR = E':
+        receipted = emitted_case['ceActualResponses'] == emitted_case['ceExpectedCapacity']
+
+    if receipted == 'AR > E':
+        receipted = emitted_case['ceActualResponses'] > emitted_case['ceExpectedCapacity']
 
     test_helper.assertEqual(str(emitted_case['receiptReceived']), str(receipted),
                             "Receipted status on case updated event does not match expected")


### PR DESCRIPTION
# Motivation and Context
UPDATE message being sent to Field when AR > ER which shouldn't happen

# What has changed
Now follows these rules:

- AR < ER (Send UPDATE)
- AR = ER (Send CANCEL)
- AR > ER (Send nothing)
- ER = null (Send nothing)

New scenario included to separate out when AR > ER as it needs to go through receipting process twice

# How to test?
Build case-processor image and run ATs
Load a sample and set the actualResponses/expected and check the variations send (or don't send) the correct output

# Links
https://trello.com/c/OEL6bfx5
https://collaborate2.ons.gov.uk/confluence/display/SDC/Receipting