### PR TITLE
Add scenarios for forbidden ccs/census cross linking

### DIFF
--- a/acceptance_tests/features/ops_ui.feature
+++ b/acceptance_tests/features/ops_ui.feature
@@ -34,3 +34,20 @@ Feature: Finding cases on R-ops UI
     And a user navigates to the case details page for the chosen case
     When the user submits a bad QID to be linked to the case
     Then a failed to find QID message is flashed
+
+  Scenario: Linking a CCS QID to a non CCS case is forbidden
+    Given sample file "sample_1_english_HH_unit.csv" is loaded successfully
+    And an unaddressed QID request message of questionnaire type 71 is sent
+    And a UAC updated message with "71" questionnaire type is emitted
+    And a user navigates to the case details page for the chosen case
+    When the user submits the CCS QID to be linked to the case
+    Then an error message telling them linking a CCS QID to a non CCS case is forbidden is flashed
+
+  Scenario: Linking a non CCS QID to a CCS case is forbidden
+    Given a CCS Property Listed event with address type "HH" and estab type "HOUSEHOLD" is sent with interview required set to False
+    And the CCS Property Listed case is created with address type "HH"
+    And an unaddressed QID request message of questionnaire type 01 is sent
+    And a UAC updated message with "01" questionnaire type is emitted
+    And a user navigates to the case details page for the chosen CCS case
+    When the user submits the CCS QID to be linked to the case
+    Then an error message telling them linking a non CCS QID to a CCS case is forbidden is flashed

--- a/acceptance_tests/features/steps/ops_ui.py
+++ b/acceptance_tests/features/steps/ops_ui.py
@@ -27,7 +27,7 @@ def rops_get_case_details_page(context):
 
 
 @step('a user navigates to the case details page for the chosen CCS case')
-def rops_get_case_details_page(context):
+def rops_get_CCS_case_details_page(context):
     context.case_details = context.first_case
     context.case_details_text = get_case_details_page(context.first_case['id']).text
     test_helper.assertIn('Link QID', context.case_details_text)


### PR DESCRIPTION
# Checklist
Reminder: If any changes have been released in the [census-rm-sample-loader](https://github.com/ONSdigital/census-rm-sample-loader) or [census-rm-toolbox](https://github.com/ONSdigital/census-rm-toolbox/) then the version pins in the Pipfile need to be updated.
* [ ] Updated census-rm-toolbox version pin (if applicable)
* [ ] Updated census-rm-sample-loader version pin (if applicable)

# Motivation and Context
We want to protect against CCS and census material being cross linked in the Ops UI

# What has changed
* Add scenarios for forbidden ccs/census cross linking

# How to test?
Run against linked ops UI branch

# Links
https://trello.com/c/BH1zjT7o/2224-rops-ui-protect-against-ccs-census-qid-mismatched-links-5
https://github.com/ONSdigital/census-rm-ops-ui/pull/10